### PR TITLE
For #25857 - Top level knobs are no longer reset on file open!

### DIFF
--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -218,7 +218,7 @@ class TankWriteNodeHandler(object):
         self._app.log_debug("Created Shotgun Write Node %s" % node.name())
 
         # set the profile:
-        self.__set_profile(node, profile_name, True)
+        self.__set_profile(node, profile_name, reset_all_settings=True)
 
         return node
 
@@ -1624,7 +1624,7 @@ class TankWriteNodeHandler(object):
         if knob.name() == "tk_profile_list":
             # change the profile for the specified node:
             new_profile_name = knob.value()
-            self.__set_profile(node, new_profile_name, True)
+            self.__set_profile(node, new_profile_name, reset_all_settings=True)
             
         elif knob.name() == TankWriteNodeHandler.OUTPUT_KNOB_NAME:
             # internal cached output has been changed!


### PR DESCRIPTION
Previously, defining a setting in a Write node profile that was represented by a knob on the Shotgun Write node (e.g. colorspace) would mean that the knob was reset every time the script was opened.  This has
now been fixed and these values are only reset when changing to a different profile that also defines the setting.
