### PR TITLE
#29569 Fix incorrect proxy path setting when converting to Write nodes

### DIFF
--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -375,9 +375,12 @@ class TankWriteNodeHandler(object):
             new_wn = nuke.createNode("Write")
             new_wn.setSelected(False)
         
-            # copy across file & proxy knobs:
+            # copy across file & proxy knobs (if we've defined a proxy template):
             new_wn["file"].setValue(sg_wn["cached_path"].evaluate())
-            new_wn["proxy"].setValue(sg_wn["tk_cached_proxy_path"].evaluate())
+            if sg_wn["proxy_render_template"].value():
+                new_wn["proxy"].setValue(sg_wn["tk_cached_proxy_path"].evaluate())
+            else:
+                new_wn["proxy"].setValue("")
 
             # make sure file_type is set properly:
             int_wn = sg_wn.node(TankWriteNodeHandler.WRITE_NODE_NAME)


### PR DESCRIPTION
If no `render_proxy_template` is specified in the settings, this fix ensures that when converting to Nuke Write nodes, the proxy value is empty. Previously it was being set to the `render_template` path.