### PR TITLE
Allows promotion of write knobs to the gizmo.

### DIFF
--- a/gizmos/WriteTank.gizmo
+++ b/gizmos/WriteTank.gizmo
@@ -290,6 +290,112 @@ Gizmo {
     T Write1.reload
     -STARTLINE
  }
+
+ addUserKnob {
+    26 "" 
+    l "" 
+    +STARTLINE
+ }
+ addUserKnob {
+    41 _promoted_0
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_1
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_2
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_3
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_4
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_5
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_6
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_7
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_8
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_9
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_10
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_11
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_12
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_13
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_14
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_15
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_16
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_17
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_18
+    l Promoted
+    +INVISIBLE
+ }
+ addUserKnob {
+    41 _promoted_19
+    l Promoted
+    +INVISIBLE
+ }
  
  knobChanged "import nuke\nif hasattr(nuke, \"_shotgun_write_node_handler\"):\n    nuke._shotgun_write_node_handler.on_knob_changed_gizmo_callback()"
  onCreate "import nuke\nif hasattr(nuke, \"_shotgun_write_node_handler\"):\n    nuke._shotgun_write_node_handler.on_node_created_gizmo_callback()"

--- a/info.yml
+++ b/info.yml
@@ -73,6 +73,14 @@ configuration:
                                      Specify an empty list to use the default colour."
                     allows_empty: True
                     default_value: []
+                promote_write_knobs:
+                    type: list
+                    values:
+                        type: str
+                    description:    "Specify a list of knob names that should be promoted from the internal write node
+                                     up to the user interface of the gizmo."
+                    allows_empty: True
+                    default_value: []
 
 
     template_script_work:

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -1006,8 +1006,7 @@ class TankWriteNodeHandler(object):
         write_node = node.node(TankWriteNodeHandler.WRITE_NODE_NAME)
         # We'll use link knobs to tie our top-level knob to the write node's
         # knob that we want to promote.
-        i = 0
-        for knob_name in promote_write_knobs:
+        for i, knob_name in enumerate(promote_write_knobs):
             link_name = "_promoted_" + str(i)
             # We have 20 link knobs stashed away to use.  If we overflow that
             # then we will simply create a new link knob and deal with the
@@ -1027,10 +1026,9 @@ class TankWriteNodeHandler(object):
             link_knob.setLabel(write_node.knob(knob_name).label())
             link_knob.clearFlag(nuke.INVISIBLE)
             self._promoted_knobs.append(link_knob)
-            i += 1
         # Adding knobs might have caused us to jump tabs, so we will set
         # back to the first tab.
-        if i > 19:
+        if len(promote_write_knobs) > 19:
             node.setTab(0)
 
         # write the template name to the node so that we know it later

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -48,6 +48,7 @@ class TankWriteNodeHandler(object):
         self._script_template = self._app.get_template("template_script_work")
         
         # cache the profiles:
+        self._promoted_knobs = []
         self._profile_names = []
         self._profiles = {}
         for profile in self._app.get_setting("write_nodes", []):
@@ -59,7 +60,7 @@ class TankWriteNodeHandler(object):
             
             self._profile_names.append(name)
             self._profiles[name] = profile
-            
+        
         self.__currently_rendering_nodes = set()
         self.__node_computed_path_settings_cache = {}
         self.__path_preview_cache = {}
@@ -978,6 +979,7 @@ class TankWriteNodeHandler(object):
         file_type = profile["file_type"]
         file_settings = profile["settings"]
         tile_color = profile["tile_color"]
+        promote_write_knobs = profile.get("promote_write_knobs", [])
 
         # Make sure any invalid entries are removed from the profile list:
         list_profiles = node.knob("tk_profile_list").values()
@@ -995,6 +997,41 @@ class TankWriteNodeHandler(object):
         # they get serialized with the script:
         self.__update_knob_value(node, "tk_file_type", file_type)
         self.__update_knob_value(node, "tk_file_type_settings", pickle.dumps(file_settings))
+
+        # Hide the promoted knobs that might exist from the previously
+        # active profile.
+        for promoted_knob in self._promoted_knobs:
+            promoted_knob.setFlag(nuke.INVISIBLE)
+        self._promoted_knobs = []
+        write_node = node.node(TankWriteNodeHandler.WRITE_NODE_NAME)
+        # We'll use link knobs to tie our top-level knob to the write node's
+        # knob that we want to promote.
+        i = 0
+        for knob_name in promote_write_knobs:
+            link_name = "_promoted_" + str(i)
+            # We have 20 link knobs stashed away to use.  If we overflow that
+            # then we will simply create a new link knob and deal with the
+            # fact that it will end up in a "User" tab in the UI. The reason
+            # that we store a gaggle of link knobs on the gizmo is that it's
+            # the only way to present the promoted knobs in the write node's
+            # primary tab.  Adding knobs after the node exists results in them
+            # being shoved into a "User" tab all by themselves, which is lame.
+            if i > 19:
+                link_knob = nuke.Link_Knob(link_name)
+            else:
+                # We have to pull the link knobs from the knobs dict rather than
+                # by name, otherwise we'll get the link target and not the link
+                # itself if this is a link that was previously used.
+                link_knob = node.knobs()[link_name]
+            link_knob.setLink(write_node.fullName() + "." + knob_name)
+            link_knob.setLabel(write_node.knob(knob_name).label())
+            link_knob.clearFlag(nuke.INVISIBLE)
+            self._promoted_knobs.append(link_knob)
+            i += 1
+        # Adding knobs might have caused us to jump tabs, so we will set
+        # back to the first tab.
+        if i > 19:
+            node.setTab(0)
 
         # write the template name to the node so that we know it later
         self.__update_knob_value(node, "render_template", render_template.name)


### PR DESCRIPTION
Allows for  knobs of the internal write node to be promoted to the
interface of the gizmo by way of link knobs that are linked and shown
dynamically at profile load time. The list of knobs to promote are
pulled from the “promote_write_knobs” key that can be defined as part
of the profile’s config definition.