### PR TITLE
#36547 Removed refresh optimization

### DIFF
--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -1289,7 +1289,7 @@ class TankWriteNodeHandler(object):
                 self._app.log_debug(
                     "Promoted write node knob settings to be applied: %s" % filtered_settings
                 )
-                write_node.readKnobs(r"\n".join(filtered_settings))
+                write_node.readKnobs("\n".join(filtered_settings))
                 self.reset_render_path(node)
 
     def __set_output(self, node, output_name):

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -1786,10 +1786,6 @@ class TankWriteNodeHandler(object):
         if not isinstance(node, nuke.Gizmo):
             return
         
-        if self.__is_node_fully_constructed(node):
-            # node has already been constructed for this session!
-            return
-        
         self._app.log_debug("Setting up new node...")
         
         # populate the profiles list as this isn't stored with the file and is


### PR DESCRIPTION
This addresses the following user story:
- I have tank write nodes in a file which i have previously worked on and saved for a shot.
- I start up nuke in the project context where i have a nuke write node app added with no profiles registered (this is a required workaround due to another known issue in the nuke engine).
- Immediately after startup into project context, I select a my saved shot nuke script from the recent files menu.
- As the scene loads, the project config is still active and will trigger nuke write node callbacks at scene load that link back to the still active project context config. Write nodes will be created but because their profile will not be known to the project config, they will show up in an "unknown" state.
- As the scene has completed loading, the engine switch triggers.
- As the nuke write node app starts back up, this time in the shot context, it does scan the scene, but due to optimizations it doesn't re-process any nuke write nodes that have already been processed, effectively leaving them all in an "uknown" state.

This fix simply removes the optimization. We need to test carefully to ensure there aren't any sideeffects with this change.
