### PR TITLE
#38320: Adds a Python tab equivalent to the encapsulated Write node's.

### DIFF
--- a/gizmos/WriteTank.gizmo
+++ b/gizmos/WriteTank.gizmo
@@ -402,6 +402,15 @@ Gizmo {
     l Promoted
     +INVISIBLE
  }
+ addUserKnob {
+    20 Python
+    l "Python"
+ }
+ addUserKnob {1 tk_before_render l "before render"}
+ addUserKnob {41 beforeFrameRender l "before each frame" T Write1.beforeFrameRender}
+ addUserKnob {41 afterFrameRender l "after each frame" T Write1.afterFrameRender}
+ addUserKnob {1 tk_after_render l "after render"}
+ addUserKnob {41 renderProgress l "render progress" T Write1.renderProgress}
  
  knobChanged "import nuke\nif hasattr(nuke, \"_shotgun_write_node_handler\"):\n    nuke._shotgun_write_node_handler.on_knob_changed_gizmo_callback()"
  onCreate "import nuke\nif hasattr(nuke, \"_shotgun_write_node_handler\"):\n    nuke._shotgun_write_node_handler.on_node_created_gizmo_callback()"

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -744,6 +744,13 @@ class TankWriteNodeHandler(object):
         if grp:
             self.__currently_rendering_nodes.add(grp)
 
+        # Run any beforeRender code that the user added in the node's Python
+        # tab manually.
+        cmd = grp.knob("tk_before_render").value()
+
+        if cmd:
+            exec(cmd)
+
     def on_after_render_gizmo_callback(self):
         """
         Callback from nuke whenever a tank write node has finished being rendered
@@ -757,6 +764,13 @@ class TankWriteNodeHandler(object):
         grp = nuke.thisGroup()
         if grp and grp in self.__currently_rendering_nodes:
             self.__currently_rendering_nodes.remove(grp)
+
+        # Run any afterRender code that the user added in the node's Python
+        # tab manually.
+        cmd = grp.knob("tk_after_render").value()
+
+        if cmd:
+            exec(cmd)
 
 
     ################################################################################################

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -749,8 +749,12 @@ class TankWriteNodeHandler(object):
         cmd = grp.knob("tk_before_render").value()
 
         if cmd:
-            exec(cmd)
-
+            try:
+                exec(cmd)
+            except Exception:
+                self._app.log_error("The Write node's beforeRender setting failed "
+                                    "to execute!")
+                raise
     def on_after_render_gizmo_callback(self):
         """
         Callback from nuke whenever a tank write node has finished being rendered
@@ -770,8 +774,12 @@ class TankWriteNodeHandler(object):
         cmd = grp.knob("tk_after_render").value()
 
         if cmd:
-            exec(cmd)
-
+            try:
+                exec(cmd)
+            except Exception:
+                self._app.log_error("The Write node's afterRender setting failed "
+                                    "to execute!")
+                raise
 
     ################################################################################################
     # Private methods


### PR DESCRIPTION
For beforeRender and afterRender, we have to use a custom knob rather than promoting the Write node's to the top. This is because we already populate those two Write node's knobs with code necessary for the functioning of the gizmo. We just take what the user puts into the custom knobs and `exec()` it from the existing callback that we have registered for pre- and post-render. The end result is that it behaves the same as if the user had direct access to the encapsulated Write node's beforeRender and afterRender knobs.

The other knobs in the Write node's Python tab are promoted and accessed directly.