### PR TITLE
Added public function to create new write node

### DIFF
--- a/app.py
+++ b/app.py
@@ -216,9 +216,7 @@ class NukeWriteNode(tank.platform.Application):
     
     def create_new_write_node(self, profile_name):
         """
-        Convert all Shotgun write nodes found in the current Script to regular
-        Nuke Write nodes.  Additional toolkit information will be stored on 
-        additional user knobs named 'tk_*'
+        Creates a Shotgun write node using the provided profile_name.  
         """
         self.__write_node_handler.create_new_node(profile_name)
 

--- a/app.py
+++ b/app.py
@@ -213,7 +213,15 @@ class NukeWriteNode(tank.platform.Application):
         from Shotgun Write nodes, back into Shotgun Write nodes.
         """
         self.__write_node_handler.convert_nuke_to_sg_write_nodes()
-        
+    
+    def create_new_write_node(self, profile_name):
+        """
+        Convert all Shotgun write nodes found in the current Script to regular
+        Nuke Write nodes.  Additional toolkit information will be stored on 
+        additional user knobs named 'tk_*'
+        """
+        self.__write_node_handler.create_new_node(profile_name)
+
     # Private methods
     #
     def __add_write_node_commands(self, context=None):


### PR DESCRIPTION
I wanted to set my 'w' keyboard shortcut to the SG write-node. The only
way I could see to do this without hard-coding it in to the app was to
create this public function that I could call from menu.py eg :
def SGCreateWriteNode():
import sgtk
eng = sgtk.platform.current_engine()
try:
app = eng.apps["tk-nuke-writenode"]
app.create_new_write_node('some_preset_profile_ name')
except:
nuke.createNode( "Write" )

ToolbarMenu.addCommand('Tools/Create SG Write
Node',"SGCreateWriteNode()", 'w')