### PR TITLE
#39647: Addresses a ValueError raised by Nuke during new node setup.

### DIFF
--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -15,6 +15,7 @@ import pickle
 import datetime
 import base64
 import re
+import functools
 
 import nuke
 import nukescripts
@@ -22,6 +23,7 @@ import nukescripts
 import tank
 from tank import TankError
 from tank.platform import constants
+from tank.platform.qt import QtCore
 
 # Special exception raised when the work file cannot be resolved.
 class TkComputePathError(TankError):
@@ -60,6 +62,7 @@ class TankWriteNodeHandler(object):
         # flags to track when the render and proxy paths are being updated.
         self.__is_updating_render_path = False
         self.__is_updating_proxy_path = False
+        self.__timer = None
 
         self.populate_profiles_from_settings()
             
@@ -582,7 +585,25 @@ class TankWriteNodeHandler(object):
         be when the node is created for the first time or when it is loaded
         or imported/pasted from an existing script.
         """
-        self.__setup_new_node(nuke.thisNode())
+        # This is unfortunate. In Nuke 10.0 we have a problem whereby Nuke
+        # is sometimes triggering this callback at a time when its root
+        # node isn't completely initialized. As a result, we get some bogus
+        # noise in the form of ValueErrors complaining about the lack of
+        # a PythonObject attached to the node. The not-ideal solution is to
+        # delay the callback by a short period of time -- half a second --
+        # before allowing it to actually be called. This gives Nuke enough
+        # time to complete its root-node initialization and all is well.
+        if not self.__timer:
+            self.__timer = QtCore.QTimer()
+            self.__timer.setSingleShot(True)
+            self.__timer.timeout.connect(
+                functools.partial(
+                    self.__setup_new_node,
+                    nuke.thisNode(),
+                ),
+            )
+
+        self.__timer.start(500)
 
     def on_compute_path_gizmo_callback(self):
         """

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -62,7 +62,7 @@ class TankWriteNodeHandler(object):
         # flags to track when the render and proxy paths are being updated.
         self.__is_updating_render_path = False
         self.__is_updating_proxy_path = False
-        self.__timer = None
+        self.__nuke_10_setup_timer = None
 
         self.populate_profiles_from_settings()
             
@@ -590,20 +590,20 @@ class TankWriteNodeHandler(object):
         # node isn't completely initialized. As a result, we get some bogus
         # noise in the form of ValueErrors complaining about the lack of
         # a PythonObject attached to the node. The not-ideal solution is to
-        # delay the callback by a short period of time -- half a second --
+        # delay the callback by a short period of time -- 100 milliseconds --
         # before allowing it to actually be called. This gives Nuke enough
         # time to complete its root-node initialization and all is well.
-        if not self.__timer:
-            self.__timer = QtCore.QTimer()
-            self.__timer.setSingleShot(True)
-            self.__timer.timeout.connect(
+        if not self.__nuke_10_setup_timer:
+            self.__nuke_10_setup_timer = QtCore.QTimer()
+            self.__nuke_10_setup_timer.setSingleShot(True)
+            self.__nuke_10_setup_timer.timeout.connect(
                 functools.partial(
                     self.__setup_new_node,
                     nuke.thisNode(),
                 ),
             )
 
-        self.__timer.start(500)
+        self.__nuke_10_setup_timer.start(100)
 
     def on_compute_path_gizmo_callback(self):
         """


### PR DESCRIPTION
We have an issue where Nuke is triggering a setup callback when its root node hasn't finished being formed. As a result, calls to node.width and node.height during path computation triggers Nuke to raise a ValueError with a cryptic message about a PythonObject not being attached to the node. By slightly delaying the execution of the callback we avoid the problem.