### PR TITLE
Addressing "a pythonObject is not attached to a node"

### DIFF
--- a/gizmos/WriteTank.gizmo
+++ b/gizmos/WriteTank.gizmo
@@ -413,7 +413,7 @@ Gizmo {
  addUserKnob {41 renderProgress l "render progress" T Write1.renderProgress}
  
  knobChanged "import nuke\nif hasattr(nuke, \"_shotgun_write_node_handler\"):\n    nuke._shotgun_write_node_handler.on_knob_changed_gizmo_callback()"
- onCreate "import nuke\nif hasattr(nuke, \"_shotgun_write_node_handler\"):\n    nuke._shotgun_write_node_handler.on_node_created_gizmo_callback()"
+ onCreate "import nuke\nif hasattr(nuke, \"_shotgun_write_node_handler\"):\n    func = nuke._shotgun_write_node_handler.on_node_created_gizmo_callback()\n    func.next()\n    func.send(func)\n"
 }
  Input {
   inputs 0

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -22,6 +22,7 @@ import nukescripts
 import tank
 from tank import TankError
 from tank.platform import constants
+from tank.platform.qt import QtCore
 
 # Special exception raised when the work file cannot be resolved.
 class TkComputePathError(TankError):
@@ -582,7 +583,13 @@ class TankWriteNodeHandler(object):
         be when the node is created for the first time or when it is loaded
         or imported/pasted from an existing script.
         """
-        self.__setup_new_node(nuke.thisNode())
+        current_node = nuke.thisNode()
+        calling_function = yield
+        QtCore.QTimer.singleShot(100, calling_function.next)
+        yield
+        self.__setup_new_node(current_node)
+        yield
+
 
     def on_compute_path_gizmo_callback(self):
         """


### PR DESCRIPTION
Using a python generator with the QTimer solution explored in a839b36. This fix has been tested successfully in Nuke10.0v3 and Nuke10.5v4.