### PR TITLE
Added ability to set tank_channel and use_node_name in environment file

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -48,6 +48,11 @@ configuration:
                     type: dict
                 tank_type:
                     type: tank_type
+                tank_channel:
+                    type: str
+                use_node_name:
+                    type: bool
+                    default_value: False
                 render_template:
                     type: template
                     fields: context, version, SEQ, [channel], [output], [name], [width], [height], [eye], [YYYY], [MM], [DD], *

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -15,7 +15,6 @@ import pickle
 import datetime
 import base64
 import re
-import functools
 
 import nuke
 import nukescripts
@@ -23,7 +22,6 @@ import nukescripts
 import tank
 from tank import TankError
 from tank.platform import constants
-from tank.platform.qt import QtCore
 
 # Special exception raised when the work file cannot be resolved.
 class TkComputePathError(TankError):
@@ -62,7 +60,6 @@ class TankWriteNodeHandler(object):
         # flags to track when the render and proxy paths are being updated.
         self.__is_updating_render_path = False
         self.__is_updating_proxy_path = False
-        self.__nuke_10_setup_timer = None
 
         self.populate_profiles_from_settings()
             
@@ -585,25 +582,7 @@ class TankWriteNodeHandler(object):
         be when the node is created for the first time or when it is loaded
         or imported/pasted from an existing script.
         """
-        # This is unfortunate. In Nuke 10.0 we have a problem whereby Nuke
-        # is sometimes triggering this callback at a time when its root
-        # node isn't completely initialized. As a result, we get some bogus
-        # noise in the form of ValueErrors complaining about the lack of
-        # a PythonObject attached to the node. The not-ideal solution is to
-        # delay the callback by a short period of time -- 100 milliseconds --
-        # before allowing it to actually be called. This gives Nuke enough
-        # time to complete its root-node initialization and all is well.
-        if not self.__nuke_10_setup_timer:
-            self.__nuke_10_setup_timer = QtCore.QTimer()
-            self.__nuke_10_setup_timer.setSingleShot(True)
-            self.__nuke_10_setup_timer.timeout.connect(
-                functools.partial(
-                    self.__setup_new_node,
-                    nuke.thisNode(),
-                ),
-            )
-
-        self.__nuke_10_setup_timer.start(100)
+        self.__setup_new_node(nuke.thisNode())
 
     def on_compute_path_gizmo_callback(self):
         """


### PR DESCRIPTION
I wanted the ability to set default values for the tank_channel and use_node_name parameters on the shotgun write node. This pull request just exposes those to the environment configuration definition.