### PR TITLE
For #43714 and #44898: Promoted knobs fixed and a PythonObject error fix.

### DIFF
--- a/gizmos/WriteTank.gizmo
+++ b/gizmos/WriteTank.gizmo
@@ -413,7 +413,7 @@ Gizmo {
  addUserKnob {41 renderProgress l "render progress" T Write1.renderProgress}
  
  knobChanged "import nuke\nif hasattr(nuke, \"_shotgun_write_node_handler\"):\n    nuke._shotgun_write_node_handler.on_knob_changed_gizmo_callback()"
- onCreate "import nuke\nif hasattr(nuke, \"_shotgun_write_node_handler\"):\n    nuke._shotgun_write_node_handler.on_node_created_gizmo_callback()"
+ onCreate "import nuke\nif hasattr(nuke, \"_shotgun_write_node_handler\"):\n    func = nuke._shotgun_write_node_handler.on_node_created_gizmo_callback()\n    func.next()\n    func.send(func)\n"
 }
  Input {
   inputs 0

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -1268,12 +1268,12 @@ class TankWriteNodeHandler(object):
                 # Example data after splitting:
                 #
                 # ['',
-                #  'file /shotgun/devosx/sequences/Test_Sequence/Test_Shot/Comp/work/images/scene/v004/2048x1556/Test_Shot_scene_output_main_v004.0001.exr',
-                #  'proxy /shotgun/devosx/sequences/Test_Sequence/Test_Shot/Comp/work/images/scene/v004/2048x1556/Test_Shot_scene_output_main_v004.0001.exr',
+                #  'file /some/path/to/an/image.exr',
+                #  'proxy /some/path/to/an/image.exr',
                 #  'file_type exr',
                 #  'datatype "32 bit float"',
-                #  'beforeRender "import nuke\\nif hasattr(nuke, \\"_shotgun_write_node_handler\\"):\\n    nuke._shotgun_write_node_handler.on_before_render_gizmo_callback()"',
-                #  'afterRender "import nuke\\nif hasattr(nuke, \\"_shotgun_write_node_handler\\"):\\n    nuke._shotgun_write_node_handler.on_after_render_gizmo_callback()"']
+                #  'beforeRender "<beforeRender callback script>"',
+                #  'afterRender "<afterRender callback script"']
                 for setting in re.split(r"\n", knob_settings):
                     # We match the name of the knob, which is everything up to
                     # the first space character. From the example data above,

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -1273,7 +1273,7 @@ class TankWriteNodeHandler(object):
                 #  'file_type exr',
                 #  'datatype "32 bit float"',
                 #  'beforeRender "<beforeRender callback script>"',
-                #  'afterRender "<afterRender callback script"']
+                #  'afterRender "<afterRender callback script>"']
                 for setting in re.split(r"\n", knob_settings):
                     # We match the name of the knob, which is everything up to
                     # the first space character. From the example data above,

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -22,6 +22,7 @@ import nukescripts
 import tank
 from tank import TankError
 from tank.platform import constants
+from tank.platform.qt import QtCore
 
 # Special exception raised when the work file cannot be resolved.
 class TkComputePathError(TankError):
@@ -582,7 +583,13 @@ class TankWriteNodeHandler(object):
         be when the node is created for the first time or when it is loaded
         or imported/pasted from an existing script.
         """
-        self.__setup_new_node(nuke.thisNode())
+        current_node = nuke.thisNode()
+        calling_function = yield
+        QtCore.QTimer.singleShot(100, calling_function.next)
+        yield
+        self.__setup_new_node(current_node)
+        yield
+
 
     def on_compute_path_gizmo_callback(self):
         """

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -584,10 +584,24 @@ class TankWriteNodeHandler(object):
         or imported/pasted from an existing script.
         """
         current_node = nuke.thisNode()
+
+        # We're doing something different here. We have a situation where the
+        # logic in __setup_new_node might trigger an exception being raised in
+        # Nuke's framebuffer subprocess, which makes its way to the console. It
+        # doesn't break anything, but it's impossible to snuff it out since it
+        # is occurring in a different process from us here. What this is doing
+        # is staging the node created callback such that it's called slowly
+        # over a period of a couple hundred milliseconds, while giving Nuke's
+        # event loop the opportunity to iterate a couple times between phases
+        # execution. A side effect of this is that the render paths are sometimes
+        # not properly reset, most notably during some Snapshot restores. As
+        # a result, we also call the reset_render_path method to ensure everything
+        # is good there.
         calling_function = yield
         QtCore.QTimer.singleShot(100, calling_function.next)
         yield
         self.__setup_new_node(current_node)
+        self.reset_render_path(current_node)
         yield
 
 


### PR DESCRIPTION
This attempts to resolve two issues:
* Promoted write node knobs did not have their settings reapplied on file open. This is a regression that was introduced with the v1.1.6 release of the app.
* Merges in #22 for QA.
* Adds better logging surrounding promoted write node knobs setting application on file open.