### PR TITLE
SG-7398 Add convert write node menu items

### DIFF
--- a/app.py
+++ b/app.py
@@ -228,7 +228,7 @@ class NukeWriteNode(tank.platform.Application):
                 continue_with_convert = False
 
         if continue_with_convert:
-            self.__write_node_handler.convert_sg_to_nuke_write_nodes(create_folders)
+            self.__write_node_handler.convert_sg_to_nuke_write_nodes()
 
     def convert_from_write_nodes(self, show_warning=False):
         """

--- a/app.py
+++ b/app.py
@@ -312,7 +312,7 @@ class NukeWriteNode(tank.platform.Application):
                     }
                 )
                 self.engine.register_command(
-                    "Convert Write Nodes to SG Write Nodes...",
+                    "Convert Write Nodes back to SG Format...",
                     convert_from_write_nodes_action,
                     {
                         "type": "context_menu",

--- a/app.py
+++ b/app.py
@@ -215,9 +215,9 @@ class NukeWriteNode(tank.platform.Application):
         if show_warning:
             from sgtk.platform.qt import QtGui
             res = QtGui.QMessageBox.question(None,
-                                             "Convert All Shotgun Write Nodes?",
-                                             "Do you want to convert all Shotgun Nuke write nodes to Standard Nuke"
-                                             " Write nodes.",
+                                             "Convert All SG Write Nodes?",
+                                             "Do you want to convert all SG write nodes to standard Nuke "
+                                             "write nodes?",
                                              QtGui.QMessageBox.Yes | QtGui.QMessageBox.No)
 
             if res != QtGui.QMessageBox.Yes:
@@ -244,8 +244,8 @@ class NukeWriteNode(tank.platform.Application):
             res = QtGui.QMessageBox.question(None,
                                              "Convert All Write Nodes?",
                                              "Do you want to convert all standard Nuke write nodes to "
-                                             "Shotgun write nodes?"
-                                             "\n\nNote: It will only convert nodes that were previously Shotgun write "
+                                             "SG write nodes?"
+                                             "\n\nNote: It will only convert nodes that were previously SG write "
                                              "nodes. It should also be considered experimental, some settings may not "
                                              "convert back correctly.",
                                              QtGui.QMessageBox.Yes | QtGui.QMessageBox.No)

--- a/app.py
+++ b/app.py
@@ -192,7 +192,7 @@ class NukeWriteNode(tank.platform.Application):
         """
         Reset the render path of the specified node.  This
         will force the render path to be updated based on
-        the current script path and configuraton.
+        the current script path and configuration.
         
         Note, this should really never be needed now that the
         path is reset automatically when the user changes something.
@@ -204,6 +204,9 @@ class NukeWriteNode(tank.platform.Application):
         Convert all Shotgun write nodes found in the current Script to regular
         Nuke Write nodes.  Additional toolkit information will be stored on 
         additional user knobs named 'tk_*'
+
+        :param show_warning: Optional bool that sets whether a warning box should be displayed to the user;
+         defaults to False.
         """
 
         # By default we want to convert the write nodes, unless the warning is shown and the user chooses to abort.
@@ -228,6 +231,9 @@ class NukeWriteNode(tank.platform.Application):
         """
         Convert all regular Nuke Write nodes that have previously been converted
         from Shotgun Write nodes, back into Shotgun Write nodes.
+
+        :param show_warning: Optional bool that sets whether a warning box should be displayed to the user;
+         defaults to False.
         """
 
         # By default we want to convert the write nodes, unless the warning is shown and the user chooses to abort.

--- a/app.py
+++ b/app.py
@@ -225,6 +225,7 @@ class NukeWriteNode(tank.platform.Application):
     def __add_write_node_commands(self, context=None):
         """
         Creates write node menu entries for all write node configurations
+        and the convert to and from Shotgun writenode actions if configured to do so.
         """
         context = context or self.context
 
@@ -242,6 +243,25 @@ class NukeWriteNode(tank.platform.Application):
                     context=context,
                 )
             )
-            
-            
 
+        # Show the convert actions in the Menu if configured to do so
+        if self.get_setting('show_convert_actions'):
+
+            self.engine.register_command(
+                "Convert from Shotgun Write Nodes",
+                self.convert_to_write_nodes,
+                {
+                    "type": "node",
+                    "icon": os.path.join(self.disk_location, "icon_256.png"),
+                    "context": context,
+                }
+            )
+            self.engine.register_command(
+                "Convert to Shotgun Write Nodes",
+                self.convert_from_write_nodes,
+                {
+                    "type": "node",
+                    "icon": os.path.join(self.disk_location, "icon_256.png"),
+                    "context": context,
+                }
+            )

--- a/app.py
+++ b/app.py
@@ -251,7 +251,7 @@ class NukeWriteNode(tank.platform.Application):
                 "Convert from Shotgun Write Nodes",
                 self.convert_to_write_nodes,
                 {
-                    "type": "node",
+                    "type": "context_menu",
                     "icon": os.path.join(self.disk_location, "icon_256.png"),
                     "context": context,
                 }
@@ -260,7 +260,7 @@ class NukeWriteNode(tank.platform.Application):
                 "Convert to Shotgun Write Nodes",
                 self.convert_from_write_nodes,
                 {
-                    "type": "node",
+                    "type": "context_menu",
                     "icon": os.path.join(self.disk_location, "icon_256.png"),
                     "context": context,
                 }

--- a/app.py
+++ b/app.py
@@ -315,7 +315,7 @@ class NukeWriteNode(tank.platform.Application):
                     }
                 )
                 self.engine.register_command(
-                    "Convert Write Nodes back to SG Format...",
+                    "Convert Write Nodes back to SG format...",
                     convert_from_write_nodes_action,
                     {
                         "type": "context_menu",

--- a/app.py
+++ b/app.py
@@ -199,7 +199,7 @@ class NukeWriteNode(tank.platform.Application):
         """
         self.__write_node_handler.reset_render_path(node)
 
-    def convert_to_write_nodes(self, show_warning=False):
+    def convert_to_write_nodes(self, show_warning=False, create_folders=False):
         """
         Convert all Shotgun write nodes found in the current Script to regular
         Nuke Write nodes.  Additional toolkit information will be stored on 
@@ -207,6 +207,8 @@ class NukeWriteNode(tank.platform.Application):
 
         :param show_warning: Optional bool that sets whether a warning box should be displayed to the user;
          defaults to False.
+        :param create_folders: Optional bool that sets whether the operation will create the required output folders;
+         defaults to False
         """
 
         # By default we want to convert the write nodes, unless the warning is shown and the user chooses to abort.
@@ -226,7 +228,7 @@ class NukeWriteNode(tank.platform.Application):
                 continue_with_convert = False
 
         if continue_with_convert:
-            self.__write_node_handler.convert_sg_to_nuke_write_nodes()
+            self.__write_node_handler.convert_sg_to_nuke_write_nodes(create_folders)
 
     def convert_from_write_nodes(self, show_warning=False):
         """
@@ -300,7 +302,8 @@ class NukeWriteNode(tank.platform.Application):
             if not promoted_knob_write_nodes:
                 # no presets use promoted knobs so we are OK to register the menus.
 
-                convert_to_write_nodes_action = lambda :self.convert_to_write_nodes(show_warning=True)
+                convert_to_write_nodes_action = lambda :self.convert_to_write_nodes(show_warning=True,
+                                                                                    create_folders=True)
                 convert_from_write_nodes_action = lambda: self.convert_from_write_nodes(show_warning=True)
 
                 self.engine.register_command(

--- a/info.yml
+++ b/info.yml
@@ -82,9 +82,8 @@ configuration:
                     allows_empty: True
                     default_value: []
 
-    # Note that converting from a Shotgun Write Node to a standard one and then back again,
-    # may not result in the end Shotgun Write Node matching the same as the original if you are promoting write knobs.
-    # This is because some information can be lost when going to standard node.
+    # Note that if you have presets which promote write knobs, the convert menu items will not be shown, regardless
+    # of the value applied to this setting, as at present the convert back method doesn't support promoted knobs.
     show_convert_actions:
         type: bool
         description: "Setting this to True will add actions for converting to and from Shotgun write nodes.

--- a/info.yml
+++ b/info.yml
@@ -82,6 +82,14 @@ configuration:
                     allows_empty: True
                     default_value: []
 
+    # Note that converting from a Shotgun Write Node to a standard one and then back again,
+    # may not result in the end Shotgun Write Node matching the same as the original if you are promoting write knobs.
+    # This is because some information can be lost when going to standard node.
+    show_convert_actions:
+        type: bool
+        description: "Setting this to True will add actions for converting to and from Shotgun writenodes.
+                      The actions will be displayed as option next to the to the create write nodes actions."
+        default_value: False
 
     template_script_work:
         type: template

--- a/info.yml
+++ b/info.yml
@@ -87,8 +87,8 @@ configuration:
     # This is because some information can be lost when going to standard node.
     show_convert_actions:
         type: bool
-        description: "Setting this to True will add actions for converting to and from Shotgun writenodes.
-                      The actions will be displayed as option next to the to the create write nodes actions."
+        description: "Setting this to True will add actions for converting to and from Shotgun write nodes.
+                      The actions will be displayed as options in the Shotgun -> Context menu"
         default_value: False
 
     template_script_work:

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -366,7 +366,7 @@ class TankWriteNodeHandler(object):
         nuke.removeOnScriptSave(self.__on_script_save)
         nuke.removeOnUserCreate(self.__on_user_create, nodeClass=TankWriteNodeHandler.SG_WRITE_NODE_CLASS)
 
-    def convert_sg_to_nuke_write_nodes(self, create_folders=False):
+    def convert_sg_to_nuke_write_nodes(self):
         """
         Utility function to convert all Shotgun Write nodes to regular
         Nuke Write nodes.
@@ -407,6 +407,8 @@ class TankWriteNodeHandler(object):
             # make sure file_type is set properly:
             int_wn = sg_wn.node(TankWriteNodeHandler.WRITE_NODE_NAME)
             new_wn["file_type"].setValue(int_wn["file_type"].value())
+
+
         
             # copy across any knob values from the internal write node.
             for knob_name, knob in int_wn.knobs().iteritems():
@@ -421,6 +423,10 @@ class TankWriteNodeHandler(object):
                     except TypeError:
                         # ignore type errors:
                         pass
+
+            # Set the nuke write node to have create directories ticked on by default
+            # As toolkit hasn't created the output folder at this point.
+            new_wn["create_directories"].setValue(True)
         
             # copy across select knob values from the Shotgun Write node:
             for knob_name in ["tile_color", "postage_stamp", "label"]:
@@ -468,18 +474,6 @@ class TankWriteNodeHandler(object):
             new_wn.setName(node_name)
             new_wn.setXpos(node_pos[0])
             new_wn.setYpos(node_pos[1])
-
-            if create_folders:
-                # We need to ensure that the folders are created for the output paths.
-
-                out_dir = os.path.dirname(new_wn["file"].value())
-                self._app.ensure_folder_exists(out_dir)
-
-                proxy_file_path = new_wn["proxy"].value()
-                if proxy_file_path:
-                    proxy_out_dir = os.path.dirname(proxy_file_path)
-                    self._app.ensure_folder_exists(proxy_out_dir)
-
             
     def convert_nuke_to_sg_write_nodes(self):
         """

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -366,7 +366,7 @@ class TankWriteNodeHandler(object):
         nuke.removeOnScriptSave(self.__on_script_save)
         nuke.removeOnUserCreate(self.__on_user_create, nodeClass=TankWriteNodeHandler.SG_WRITE_NODE_CLASS)
 
-    def convert_sg_to_nuke_write_nodes(self):
+    def convert_sg_to_nuke_write_nodes(self, create_folders=False):
         """
         Utility function to convert all Shotgun Write nodes to regular
         Nuke Write nodes.
@@ -377,6 +377,9 @@ class TankWriteNodeHandler(object):
         app = eng.apps["tk-nuke-writenode"]
         # Convert Shotgun write nodes to Nuke write nodes:
         app.convert_to_write_nodes()
+
+        :param create_folders: When set to true, it will create the folders on disk for the render and proxy paths.
+         Defaults to false.
         """
         # clear current selection:
         nukescripts.clear_selection_recursive()
@@ -465,6 +468,18 @@ class TankWriteNodeHandler(object):
             new_wn.setName(node_name)
             new_wn.setXpos(node_pos[0])
             new_wn.setYpos(node_pos[1])
+
+            if create_folders:
+                # We need to ensure that the folders are created for the output paths.
+
+                out_dir = os.path.dirname(new_wn["file"].value())
+                self._app.ensure_folder_exists(out_dir)
+
+                proxy_file_path = new_wn["proxy"].value()
+                if proxy_file_path:
+                    proxy_out_dir = os.path.dirname(proxy_file_path)
+                    self._app.ensure_folder_exists(proxy_out_dir)
+
             
     def convert_nuke_to_sg_write_nodes(self):
         """


### PR DESCRIPTION
Adds a configurable option that enables the creation of menu items that perform the methods `convert_to_write_nodes` and `convert_from_write_nodes`.

Before this pull request, it was up to the user to create a menu item in Nuke that called these methods on the app. This a convenience option, that will enable the convert menu items to show up next to the Shotgun Write Node items.

<img width="176" alt="untitled_-_nuke" src="https://user-images.githubusercontent.com/3777228/42171148-74dca4c8-7e10-11e8-9d3d-9f580753c49e.png">

Will need to add warnings about the convert back not being 100% reliable in certain situations to the docs.