### PR TITLE
improvements to UI features of WriteTank

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
@@ -54,10 +54,10 @@ class NukeWriteNode(tank.platform.Application):
         Called when the app is unloaded/destroyed
         """
         self.log_debug("Destroying tk-nuke-writenode app")
-        
+
         # remove any callbacks that were registered by the handler:
         self.__write_node_handler.remove_callbacks()
-        
+
         # clean up the nuke module:
         if hasattr(nuke, "_shotgun_write_node_handler"):
             del nuke._shotgun_write_node_handler
@@ -78,7 +78,7 @@ class NukeWriteNode(tank.platform.Application):
         self.__write_node_handler.populate_profiles_from_settings()
         self.__write_node_handler.populate_script_template()
         self.__add_write_node_commands(new_context)
-        
+
     def process_placeholder_nodes(self):
         """
         Convert any placeholder nodes to TK Write Nodes
@@ -87,14 +87,14 @@ class NukeWriteNode(tank.platform.Application):
 
     # interface for other apps to query write node info:
     #
-    
+
     # access general information:
     def get_write_nodes(self):
         """
         Return list of all write nodes
         """
         return self.__write_node_handler.get_nodes()
-    
+
     def get_node_name(self, node):
         """
         Return the name for the specified node
@@ -107,11 +107,11 @@ class NukeWriteNode(tank.platform.Application):
         is using
         """
         return self.__write_node_handler.get_node_profile_name(node)
-    
+
     def get_node_tank_type(self, node):
         """
         Return the tank type for the specified node
-        
+
         Note: Legacy version with old 'Tank Type' name - use
         get_node_published_file_type instead!
         """
@@ -122,7 +122,7 @@ class NukeWriteNode(tank.platform.Application):
         Return the published file type for the specified node
         """
         return self.__write_node_handler.get_node_tank_type(node)
-    
+
     def is_node_render_path_locked(self, node):
         """
         Determine if the render path for the specified node
@@ -132,71 +132,71 @@ class NukeWriteNode(tank.platform.Application):
         can happen if the file is moved on disk or if the template
         is changed.
         """
-        return self.__write_node_handler.render_path_is_locked(node)    
-    
+        return self.__write_node_handler.render_path_is_locked(node)
+
     # access full-res render information:
     def get_node_render_path(self, node):
         """
         Return the render path for the specified node
         """
-        return self.__write_node_handler.compute_render_path(node)    
-    
+        return self.__write_node_handler.compute_render_path(node)
+
     def get_node_render_files(self, node):
         """
         Return the list of rendered files for the node
         """
         return self.__write_node_handler.get_files_on_disk(node)
-    
+
     def get_node_render_template(self, node):
         """
         Return the render template for the specified node
         """
         return self.__write_node_handler.get_render_template(node)
-    
+
     def get_node_publish_template(self, node):
         """
         Return the publish template for the specified node
         """
         return self.__write_node_handler.get_publish_template(node)
-    
+
     # access proxy-res render information:
     def get_node_proxy_render_path(self, node):
         """
         Return the render path for the specified node
         """
-        return self.__write_node_handler.compute_proxy_path(node)    
-    
+        return self.__write_node_handler.compute_proxy_path(node)
+
     def get_node_proxy_render_files(self, node):
         """
         Return the list of rendered files for the node
         """
         return self.__write_node_handler.get_proxy_files_on_disk(node)
-    
+
     def get_node_proxy_render_template(self, node):
         """
         Return the render template for the specified node
         """
         return self.__write_node_handler.get_proxy_render_template(node)
-    
+
     def get_node_proxy_publish_template(self, node):
         """
         Return the publish template for the specified node
         """
-        return self.__write_node_handler.get_proxy_publish_template(node)    
-    
+        return self.__write_node_handler.get_proxy_publish_template(node)
+
     # useful utility functions:
     def generate_node_thumbnail(self, node):
         """
         Generate a thumnail for the specified node
         """
         return self.__write_node_handler.generate_thumbnail(node)
-    
+
     def reset_node_render_path(self, node):
         """
         Reset the render path of the specified node.  This
         will force the render path to be updated based on
         the current script path and configuration.
-        
+
         Note, this should really never be needed now that the
         path is reset automatically when the user changes something.
         """
@@ -205,7 +205,7 @@ class NukeWriteNode(tank.platform.Application):
     def convert_to_write_nodes(self, show_warning=False):
         """
         Convert all Shotgun write nodes found in the current Script to regular
-        Nuke Write nodes.  Additional toolkit information will be stored on 
+        Nuke Write nodes.  Additional toolkit information will be stored on
         additional user knobs named 'tk_*'
 
         :param show_warning: Optional bool that sets whether a warning box should be displayed to the user;
@@ -265,7 +265,7 @@ class NukeWriteNode(tank.platform.Application):
 
     def create_new_write_node(self, profile_name):
         """
-        Creates a Shotgun write node using the provided profile_name.  
+        Creates a Shotgun write node using the provided profile_name.
         """
         self.__write_node_handler.create_new_node(profile_name)
 
@@ -284,8 +284,8 @@ class NukeWriteNode(tank.platform.Application):
             # add to toolbar menu
             cb_fn = lambda pn=profile_name: self.__write_node_handler.create_new_node(pn)
             self.engine.register_command(
-                "%s [Shotgun]" % profile_name,
-                cb_fn, 
+                "sgWrite: %s" % profile_name,
+                cb_fn,
                 dict(
                     type="node",
                     icon=write_node_icon,

--- a/app.py
+++ b/app.py
@@ -36,6 +36,9 @@ class NukeWriteNode(tank.platform.Application):
         # add WriteNodes to nuke menu
         self.__add_write_node_commands()
 
+        # add autolabel callback to WriteTank
+        self.__write_node_handler.add_autolabel()
+
         # add callbacks:
         self.__write_node_handler.add_callbacks()
 

--- a/gizmos/WriteTank.gizmo
+++ b/gizmos/WriteTank.gizmo
@@ -29,11 +29,12 @@ version 6.3
 ##########################################################################################
 
 Gizmo {
+ name sgWrite1
  note_font Verdana
  mapsize {0.15 0.15}
  addUserKnob {
-    20 tank_tab 
-    l "Shotgun Write"
+    20 tank_tab
+    l "sgWrite"
  }
  addUserKnob {
     4 tk_profile_list 
@@ -417,7 +418,7 @@ Gizmo {
 }
  Input {
   inputs 0
-  name Input1
+  name Input
   xpos 195
   ypos -74
  }

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
@@ -48,12 +48,12 @@ class TankWriteNodeHandler(object):
         """
         self._app = app
         self._script_template = self._app.get_template("template_script_work")
-        
+
         # cache the profiles:
         self._promoted_knobs = {}
         self._profile_names = []
         self._profiles = {}
-        
+
         self.__currently_rendering_nodes = set()
         self.__node_computed_path_settings_cache = {}
         self.__path_preview_cache = {}
@@ -62,17 +62,17 @@ class TankWriteNodeHandler(object):
         self.__is_updating_proxy_path = False
 
         self.populate_profiles_from_settings()
-            
+
     ################################################################################################
     # Properties
-            
+
     @property
     def profile_names(self):
         """
         return the list of available profile names
         """
         return self._profile_names
-            
+
     ################################################################################################
     # Public methods
 
@@ -87,9 +87,9 @@ class TankWriteNodeHandler(object):
             name = profile["name"]
             if name in self._profiles:
                 self._app.log_warning("Configuration contains multiple Write Node profiles called '%s'!  Only the "
-                                      "first will be available" % name)                
+                                      "first will be available" % name)
                 continue
-            
+
             self._profile_names.append(name)
             self._profiles[name] = profile
 
@@ -98,18 +98,18 @@ class TankWriteNodeHandler(object):
         Sources the current context's work file template from the parent app.
         """
         self._script_template = self._app.get_template("template_script_work")
-            
+
     def get_nodes(self):
         """
         Returns a list of tank write nodes
         """
         if nuke.exists("root"):
-            return nuke.allNodes(group=nuke.root(), 
-                                 filter=TankWriteNodeHandler.SG_WRITE_NODE_CLASS, 
+            return nuke.allNodes(group=nuke.root(),
+                                 filter=TankWriteNodeHandler.SG_WRITE_NODE_CLASS,
                                  recurseGroups = True)
         else:
             return []
-            
+
     def get_node_name(self, node):
         """
         Return the name for the specified node
@@ -121,7 +121,7 @@ class TankWriteNodeHandler(object):
         Return the name of the profile the specified node is using
         """
         return node.knob("profile_name").value()
-    
+
     def get_node_tank_type(self, node):
         """
         Return the tank type for the specified node
@@ -129,7 +129,7 @@ class TankWriteNodeHandler(object):
         settings = self.__get_node_profile_settings(node)
         if settings:
             return settings["tank_type"]
-        
+
     def get_render_template(self, node):
         """
         helper function. Returns the associated render template obj for a node
@@ -194,10 +194,10 @@ class TankWriteNodeHandler(object):
             render_path = self.__compute_render_path(node)
         except:
             return True
-        
+
         # get the cached path:
         cached_path = self.__get_render_path(node)
-        
+
         return self.__is_render_path_locked(node, render_path, cached_path)
 
     def reset_render_path(self, node):
@@ -207,7 +207,7 @@ class TankWriteNodeHandler(object):
         the current script path and configuraton
         """
         is_proxy = node.proxy()
-        self.__update_render_path(node, force_reset=True, is_proxy=is_proxy)     
+        self.__update_render_path(node, force_reset=True, is_proxy=is_proxy)
         self.__update_render_path(node, force_reset=True, is_proxy=(not is_proxy))
 
     def create_new_node(self, profile_name):
@@ -242,7 +242,7 @@ class TankWriteNodeHandler(object):
         Convert any placeholder nodes to TK Write Nodes
         """
         self._app.log_debug("Looking for placeholder nodes to process...")
-        
+
         node_found = False
         for n in nuke.allNodes("ModifyMetaData"):
             if not n.name().startswith("ShotgunWriteNodePlaceholder"):
@@ -251,7 +251,7 @@ class TankWriteNodeHandler(object):
             self._app.log_debug("Found ShotgunWriteNodePlaceholder node: %s" % n)
             metadata = n.metadata()
             profile_name = metadata.get("name")
-            output_name = metadata.get("output") or metadata.get("channel") # for backwards compatibility 
+            output_name = metadata.get("output") or metadata.get("channel") # for backwards compatibility
 
             # Make sure the profile is valid:
             if profile_name not in self._profiles:
@@ -271,7 +271,7 @@ class TankWriteNodeHandler(object):
 
             # set the output:
             self.__set_output(new_node, output_name)
-            
+
             # And remove the original metadata
             nuke.delete(n)
 
@@ -290,7 +290,7 @@ class TankWriteNodeHandler(object):
             # write gizmo that does not have the create thumbnail node
             return None
         th_node.knob("disable").setValue(False)
-        
+
         png_path = tempfile.NamedTemporaryFile(suffix=".png", prefix="tanktmp", delete=False).name
 
         # set render output - make sure to use a path with slashes on all OSes
@@ -307,10 +307,10 @@ class TankWriteNodeHandler(object):
             render_node_name = "%s.create_thumbnail" % node.name()
             # and do it - always render the first view we find.
             first_view = nuke.views()[0]
-            nuke.execute(render_node_name, 
-                         start=frame_to_render, 
-                         end=frame_to_render, 
-                         incr=1, 
+            nuke.execute(render_node_name,
+                         start=frame_to_render,
+                         end=frame_to_render,
+                         incr=1,
                          views=[first_view])
         except Exception, e:
             self._app.log_warning("Thumbnail could not be generated: %s" % e)
@@ -338,7 +338,7 @@ class TankWriteNodeHandler(object):
         # script save callback used to reset paths whenever
         # a script is saved as a new name
         nuke.addOnScriptSave(self.__on_script_save)
-        
+
         # user create callback that gets executed whenever a Shotgun Write Node
         # is created by the user
         nuke.addOnUserCreate(self.__on_user_create, nodeClass=TankWriteNodeHandler.SG_WRITE_NODE_CLASS)
@@ -382,7 +382,7 @@ class TankWriteNodeHandler(object):
         """
         Utility function to convert all Shotgun Write nodes to regular
         Nuke Write nodes.
-        
+
         # Example use:
         import sgtk
         eng = sgtk.platform.current_engine()
@@ -395,20 +395,20 @@ class TankWriteNodeHandler(object):
         """
         # clear current selection:
         nukescripts.clear_selection_recursive()
-        
+
         # get write nodes:
         sg_write_nodes = self.get_nodes()
         for sg_wn in sg_write_nodes:
-        
+
             # set as selected:
             sg_wn.setSelected(True)
             node_name = sg_wn.name()
             node_pos = (sg_wn.xpos(), sg_wn.ypos())
-            
+
             # create new regular Write node:
             new_wn = nuke.createNode("Write")
             new_wn.setSelected(False)
-        
+
             # copy across file & proxy knobs (if we've defined a proxy template):
             new_wn["file"].setValue(sg_wn["cached_path"].evaluate())
             if sg_wn["proxy_render_template"].value():
@@ -419,14 +419,14 @@ class TankWriteNodeHandler(object):
             # make sure file_type is set properly:
             int_wn = sg_wn.node(TankWriteNodeHandler.WRITE_NODE_NAME)
             new_wn["file_type"].setValue(int_wn["file_type"].value())
-        
+
             # copy across any knob values from the internal write node.
             for knob_name, knob in int_wn.knobs().iteritems():
                 # skip knobs we don't want to copy:
-                if knob_name in ["file_type", "file", "proxy", "beforeRender", "afterRender", 
+                if knob_name in ["file_type", "file", "proxy", "beforeRender", "afterRender",
                               "name", "xpos", "ypos"]:
                     continue
-                
+
                 if knob_name in new_wn.knobs():
                     try:
                         new_wn[knob_name].setValue(knob.value())
@@ -437,11 +437,11 @@ class TankWriteNodeHandler(object):
             # Set the nuke write node to have create directories ticked on by default
             # As toolkit hasn't created the output folder at this point.
             new_wn["create_directories"].setValue(True)
-        
+
             # copy across select knob values from the Shotgun Write node:
             for knob_name in ["tile_color", "postage_stamp", "label"]:
                 new_wn[knob_name].setValue(sg_wn[knob_name].value())
-        
+
             # Store Toolkit specific information on write node
             # so that we can reverse this process later
 
@@ -449,42 +449,42 @@ class TankWriteNodeHandler(object):
             knob = nuke.String_Knob("tk_profile_name")
             knob.setValue(sg_wn["profile_name"].value())
             new_wn.addKnob(knob)
-            
+
             # output
             knob = nuke.String_Knob("tk_output")
             knob.setValue(sg_wn[TankWriteNodeHandler.OUTPUT_KNOB_NAME].value())
             new_wn.addKnob(knob)
-            
+
             # use node name for output
             knob = nuke.Boolean_Knob(TankWriteNodeHandler.USE_NAME_AS_OUTPUT_KNOB_NAME)
             knob.setValue(sg_wn[TankWriteNodeHandler.USE_NAME_AS_OUTPUT_KNOB_NAME].value())
             new_wn.addKnob(knob)
-        
+
             # templates
             knob = nuke.String_Knob("tk_render_template")
             knob.setValue(sg_wn["render_template"].value())
             new_wn.addKnob(knob)
-            
+
             knob = nuke.String_Knob("tk_publish_template")
             knob.setValue(sg_wn["publish_template"].value())
             new_wn.addKnob(knob)
-            
+
             knob = nuke.String_Knob("tk_proxy_render_template")
             knob.setValue(sg_wn["proxy_render_template"].value())
             new_wn.addKnob(knob)
-            
+
             knob = nuke.String_Knob("tk_proxy_publish_template")
             knob.setValue(sg_wn["proxy_publish_template"].value())
             new_wn.addKnob(knob)
-        
+
             # delete original node:
             nuke.delete(sg_wn)
-        
+
             # rename new node:
             new_wn.setName(node_name)
             new_wn.setXpos(node_pos[0])
             new_wn.setYpos(node_pos[1])
-            
+
     def convert_nuke_to_sg_write_nodes(self):
         """
         Utility function to convert all Nuke Write nodes to Shotgun
@@ -495,17 +495,17 @@ class TankWriteNodeHandler(object):
         import sgtk
         eng = sgtk.platform.current_engine()
         app = eng.apps["tk-nuke-writenode"]
-        # Convert previously converted Nuke write nodes back to 
+        # Convert previously converted Nuke write nodes back to
         # Shotgun write nodes:
         app.convert_from_write_nodes()
         """
         # clear current selection:
         nukescripts.clear_selection_recursive()
-        
+
         # get write nodes:
         write_nodes = nuke.allNodes(group=nuke.root(), filter="Write", recurseGroups = True)
         for wn in write_nodes:
-        
+
             # look for additional toolkit knobs:
             profile_knob = wn.knob("tk_profile_name")
             output_knob = wn.knob("tk_output")
@@ -514,7 +514,7 @@ class TankWriteNodeHandler(object):
             publish_template_knob = wn.knob("tk_publish_template")
             proxy_render_template_knob = wn.knob("tk_proxy_render_template")
             proxy_publish_template_knob = wn.knob("tk_proxy_publish_template")
-        
+
             if (not profile_knob
                 or not output_knob
                 or not use_name_as_output_knob
@@ -529,7 +529,7 @@ class TankWriteNodeHandler(object):
             wn.setSelected(True)
             node_name = wn.name()
             node_pos = (wn.xpos(), wn.ypos())
-            
+
             # create new Shotgun Write node:
             new_sg_wn = nuke.createNode(TankWriteNodeHandler.SG_WRITE_NODE_CLASS)
             new_sg_wn.setSelected(False)
@@ -541,7 +541,7 @@ class TankWriteNodeHandler(object):
             new_sg_wn["publish_template"].setValue(publish_template_knob.value())
             new_sg_wn["proxy_render_template"].setValue(proxy_render_template_knob.value())
             new_sg_wn["proxy_publish_template"].setValue(proxy_publish_template_knob.value())
-            
+
             # set the profile & output - this will cause the paths to be reset:
             # Note, we don't call the method __set_profile() as we don't want to
             # run all the normal logic that runs as part of switching the profile.
@@ -560,33 +560,33 @@ class TankWriteNodeHandler(object):
             # copy across and knob values from the internal write node.
             for knob_name, knob in wn.knobs().iteritems():
                 # skip knobs we don't want to copy:
-                if knob_name in ["file_type", "file", "proxy", "beforeRender", "afterRender", 
+                if knob_name in ["file_type", "file", "proxy", "beforeRender", "afterRender",
                               "name", "xpos", "ypos", "disable", "tile_color", "postage_stamp",
                               "label"]:
                     continue
-                
+
                 if knob_name in int_wn.knobs():
                     try:
                         int_wn[knob_name].setValue(knob.value())
                     except TypeError:
                         # ignore type errors:
                         pass
-        
+
             # explicitly copy some settings to the new Shotgun Write Node instead:
             for knob_name in ["disable", "tile_color", "postage_stamp"]:
                 new_sg_wn[knob_name].setValue(wn[knob_name].value())
-                
+
             # delete original node:
             nuke.delete(wn)
-        
+
             # rename new node:
             new_sg_wn.setName(node_name)
             new_sg_wn.setXpos(node_pos[0])
-            new_sg_wn.setYpos(node_pos[1])       
+            new_sg_wn.setYpos(node_pos[1])
 
 
     ################################################################################################
-    # Public methods called from gizmo - although these are public, they should 
+    # Public methods called from gizmo - although these are public, they should
     # be considered as private and not used directly!
 
     def on_knob_changed_gizmo_callback(self):
@@ -613,15 +613,15 @@ class TankWriteNodeHandler(object):
     def on_compute_path_gizmo_callback(self):
         """
         Callback executed when nuke requests the location of the std output to be computed on the internal Write
-        node.  Returns a path on disk. This will return the path in a form that Nuke likes (eg. with slashes). 
-        
+        node.  Returns a path on disk. This will return the path in a form that Nuke likes (eg. with slashes).
+
         It also updates the preview fields on the node. and the UI
         """
         # the ShotgunWrite node is the current node's parent:
         node = nuke.thisParent()
         if not node:
             return
-        
+
         # don't do anything until the node is fully constructed!
         if not self.__is_node_fully_constructed(node):
             return
@@ -633,13 +633,13 @@ class TankWriteNodeHandler(object):
     def on_compute_proxy_path_gizmo_callback(self):
         """
         Callback executed when nuke requests the location of the std output to be computed on the internal Write
-        node.  Returns a path on disk. This will return the path in a form that Nuke likes (eg. with slashes). 
+        node.  Returns a path on disk. This will return the path in a form that Nuke likes (eg. with slashes).
         """
         # the ShotgunWrite node is the current node's parent:
         node = nuke.thisParent()
         if not node:
             return
-        
+
         # don't do anything until the node is fully constructed!
         if not self.__is_node_fully_constructed(node):
             return
@@ -647,7 +647,7 @@ class TankWriteNodeHandler(object):
         # return the render path but don't reset it:
         path = self.__update_render_path(node, is_proxy=True)
         return path
-    
+
     def on_show_in_fs_gizmo_callback(self):
         """
         Shows the location of the node in the file system.
@@ -657,7 +657,7 @@ class TankWriteNodeHandler(object):
         node = nuke.thisNode()
         if not node:
             return
-        
+
         render_dir = None
 
         # first, try to just use the current cached path:
@@ -667,11 +667,11 @@ class TankWriteNodeHandler(object):
             # the above method returns nuke style slashes, so ensure these
             # are pointing correctly
             render_path = render_path.replace("/", os.path.sep)
-            
+
             dir_name = os.path.dirname(render_path)
             if os.path.exists(dir_name):
                 render_dir = dir_name
-                
+
         if not render_dir:
             # render directory doesn't exist so try using location
             # of rendered frames instead:
@@ -680,14 +680,14 @@ class TankWriteNodeHandler(object):
                 if len(files) == 0:
                     nuke.message("There are no %srenders for this node yet!\n"
                              "When you render, the files will be written to "
-                             "the following location:\n\n%s" 
+                             "the following location:\n\n%s"
                              % (("proxy " if is_proxy else ""), render_path))
                 else:
                     render_dir = os.path.dirname(files[0])
             except Exception, e:
-                nuke.message("Unable to jump to file system:\n\n%s" % e)                
-        
-        # if we have a valid render path then show it:      
+                nuke.message("Unable to jump to file system:\n\n%s" % e)
+
+        # if we have a valid render path then show it:
         if render_dir:
             system = sys.platform
 
@@ -713,28 +713,28 @@ class TankWriteNodeHandler(object):
         node = nuke.thisNode()
         if not node:
             return
-        
+
         self.reset_render_path(node)
-    
+
     def on_copy_path_to_clipboard_gizmo_callback(self):
         """
         Callback from the gizmo whenever the 'Copy path to clipboard' button
         is pressed.
         """
         node = nuke.thisNode()
-        
+
         # get the path depending if in full or proxy mode:
         is_proxy = node.proxy()
         render_path = self.__get_render_path(node, is_proxy)
-        
+
         # use Qt to copy the path to the clipboard:
         from sgtk.platform.qt import QtGui
         QtGui.QApplication.clipboard().setText(render_path)
-    
+
     def on_before_render_gizmo_callback(self):
         """
         Callback from nuke whenever a tank write node is about to be rendered.
-        """        
+        """
         # the current node is the internal 'Write1' Write node:
         node = nuke.thisNode()
         if not node:
@@ -752,7 +752,7 @@ class TankWriteNodeHandler(object):
 
             out_dir = os.path.dirname(out_file)
             self._app.ensure_folder_exists(out_dir)
-            
+
         else:
             # stereo or odd number of views...
             for view in views:
@@ -764,7 +764,7 @@ class TankWriteNodeHandler(object):
 
                 out_dir = os.path.dirname(out_file)
                 self._app.ensure_folder_exists(out_dir)
-                
+
         # add group/parent to list of currently rendering nodes:
         grp = nuke.thisGroup()
         if grp:
@@ -784,12 +784,12 @@ class TankWriteNodeHandler(object):
     def on_after_render_gizmo_callback(self):
         """
         Callback from nuke whenever a tank write node has finished being rendered
-        """        
+        """
         # the current node is the internal 'Write1' Write node:
         node = nuke.thisNode()
         if not node:
             return
-        
+
         # remove parent/group from list of currently rendering nodes:
         grp = nuke.thisGroup()
         if grp and grp in self.__currently_rendering_nodes:
@@ -823,7 +823,7 @@ class TankWriteNodeHandler(object):
         Get the named template for the specified node.
         """
         template_name = None
-        
+
         # get the template from the nodes profile settings:
         settings = self.__get_node_profile_settings(node)
         if settings:
@@ -835,13 +835,13 @@ class TankWriteNodeHandler(object):
             # the profile probably doesn't exist any more so
             # try to use the cached version
             template_name = node.knob(name).value()
-            
+
         return self._app.get_template_by_name(template_name)
-    
+
     def __get_render_template(self, node, is_proxy=False, fallback_to_render=False):
         """
         Get a specific render template for the current profile
-        
+
         :param is_proxy:            Specifies which of the two
         :param fallback_to_render:  If true and proxy template is null then the
                                     render template will be returned instead.
@@ -851,8 +851,8 @@ class TankWriteNodeHandler(object):
             if template or not fallback_to_render:
                 return template
 
-        return self.__get_template(node, "render_template") 
-    
+        return self.__get_template(node, "render_template")
+
     def __get_publish_template(self, node, is_proxy=False):
         """
         Get a specific publish template for the current profile
@@ -861,7 +861,7 @@ class TankWriteNodeHandler(object):
             return self.__get_template(node, "proxy_publish_template")
         else:
             return self.__get_template(node, "publish_template")
-    
+
     def __is_output_used(self, node):
         """
         Determine if output key is used in either the render or the proxy render
@@ -869,26 +869,26 @@ class TankWriteNodeHandler(object):
         """
         render_template = self.__get_render_template(node, is_proxy=False)
         proxy_render_template = self.__get_render_template(node, is_proxy=True)
-        
+
         for template in [render_template, proxy_render_template]:
             if not template:
                 continue
             # check for output key and also channel for backwards compatibility!
             if "output" in template.keys or "channel" in template.keys:
                 return True
-            
+
         return False
-    
+
     def __update_knob_value(self, node, name, new_value):
         """
         Update the value for the specified knob on the specified node
-        but only if it is different to the current value to avoid 
+        but only if it is different to the current value to avoid
         unneccesarily invalidating the cache
         """
         current_value = node.knob(name).value()
-        if new_value != current_value: 
+        if new_value != current_value:
             node.knob(name).setValue(new_value)
-    
+
     def __update_output_knobs(self, node):
         """
         Update output knob visibility depending if output is a key
@@ -896,14 +896,14 @@ class TankWriteNodeHandler(object):
         """
         output_knob = node.knob(TankWriteNodeHandler.OUTPUT_KNOB_NAME)
         name_as_output_knob = node.knob(TankWriteNodeHandler.USE_NAME_AS_OUTPUT_KNOB_NAME)
-        
+
         output_is_used = self.__is_output_used(node)
-        name_as_output = name_as_output_knob.value() 
-        
+        name_as_output = name_as_output_knob.value()
+
         output_knob.setEnabled(output_is_used and not name_as_output)
         output_knob.setVisible(output_is_used)
-        name_as_output_knob.setVisible(output_is_used)    
-    
+        name_as_output_knob.setVisible(output_is_used)
+
     def __update_path_preview(self, node, is_proxy):
         """
         Updates the path preview fields on the tank write node.
@@ -924,17 +924,17 @@ class TankWriteNodeHandler(object):
         else:
             # normalize the path for os platform
             norm_path = path.replace("/", os.sep)
-    
+
             # get the file name
             file_name = os.path.basename(norm_path)
             render_dir = os.path.dirname(norm_path)
-    
+
             # now get the context path
             context_path = None
             for x in self._app.context.entity_locations:
                 if render_dir.startswith(x):
                     context_path = x
-    
+
             if context_path:
                 # found a context path!
                 # chop off this bit from the normalized path
@@ -952,60 +952,60 @@ class TankWriteNodeHandler(object):
                 # e.g. for path   /mnt/proj/shotXYZ/renders/v003/hello.%04d.exr
                 # context_path:   /mnt/proj/shotXYZ/renders/v003
                 # local_path:
-    
-            self.__path_preview_cache[cache_key] = {"context_path":context_path, 
-                                                    "local_path":local_path, 
+
+            self.__path_preview_cache[cache_key] = {"context_path":context_path,
+                                                    "local_path":local_path,
                                                     "file_name":file_name}
-    
+
         # update the preview knobs - note, not sure why but
         # under certain circumstances the property editor doesn't
         # update correctly - hiding and showing the knob seems to
-        # fix this though without any noticeable side effect       
+        # fix this though without any noticeable side effect
         def set_path_knob(name, value):
             k = node.knob(name)
             if k.value() != value:
                 k.setValue(value)
             k.setVisible(False)
             k.setVisible(True)
-        
+
         set_path_knob("path_context", context_path)
         set_path_knob("path_local", local_path)
         set_path_knob("path_filename", file_name)
-        
+
 
     def __apply_cached_file_format_settings(self, node):
         """
         Apply the file_type and settings that have been cached on the node to the internal
         Write node.  This mechanism is used when the settings can't be retrieved from the
         profile for some reason.
-        
+
         :param node:    The Shotgun write node to retrieve and apply the settings on
         """
         file_type = node["tk_file_type"].value()
         if not file_type:
             return
-        
+
         file_settings_str = node["tk_file_type_settings"].value()
         file_settings = {}
         try:
             # file_settings_str is a pickled dictionary so convert it back to a dictionary:
             file_settings = pickle.loads(file_settings_str) or {}
         except Exception, e:
-            self._app.log_warning("Failed to extract cached file settings from node '%s' - %s" 
+            self._app.log_warning("Failed to extract cached file settings from node '%s' - %s"
                               % node.name(), e)
-        
+
         # update the node:
-        self.__populate_format_settings(node, file_type, file_settings)        
-        
+        self.__populate_format_settings(node, file_type, file_settings)
+
 
     def __set_profile(self, node, profile_name, reset_all_settings=False):
         """
         Set the current profile for the specified node.
-        
+
         :param node:                The Shotgun Write node to set the profile on
         :param profile_name:        The name of the profile to set on the node
-        :param reset_all_settings:  If true then all settings from the profile will be reset on the node.  If 
-                                    false, only those that _aren't_ propagated up to the Shotgun Write node will 
+        :param reset_all_settings:  If true then all settings from the profile will be reset on the node.  If
+                                    false, only those that _aren't_ propagated up to the Shotgun Write node will
                                     be reset.  For example, if colorspace has been set in the profile and force
                                     is False then the knob won't get reset to the value from the profile.
         """
@@ -1019,17 +1019,17 @@ class TankWriteNodeHandler(object):
         profile = self._profiles.get(profile_name)
         if not profile:
             # this shouldn't really every happen!
-            self._app.log_warning("Failed to find a write node profile called '%s' for node '%s'!" 
+            self._app.log_warning("Failed to find a write node profile called '%s' for node '%s'!"
                                   % profile_name, node.name())
             # at the very least, try to restore the file format settings from the cached values:
-            self.__apply_cached_file_format_settings(node)            
+            self.__apply_cached_file_format_settings(node)
             return
 
         self._app.log_debug("Changing the profile for node '%s' to: %s" % (node.name(), profile_name))
 
         # keep track of the old profile name:
         old_profile_name = node.knob("profile_name").value()
-        
+
         # pull settings from profile:
         render_template = self._app.get_template_by_name(profile["render_template"])
         publish_template = self._app.get_template_by_name(profile["publish_template"])
@@ -1048,7 +1048,7 @@ class TankWriteNodeHandler(object):
         # update both the list and the cached value for profile name:
         self.__update_knob_value(node, "profile_name", profile_name)
         self.__update_knob_value(node, "tk_profile_list", profile_name)
-        
+
         # set the format
         self.__populate_format_settings(
             node,
@@ -1057,8 +1057,8 @@ class TankWriteNodeHandler(object):
             reset_all_settings,
             promote_write_knobs,
         )
-        
-        # cache the type and settings on the root node so that 
+
+        # cache the type and settings on the root node so that
         # they get serialized with the script:
         self.__update_knob_value(node, "tk_file_type", file_type)
         self.__update_knob_value(node, "tk_file_type_settings", pickle.dumps(file_settings))
@@ -1110,9 +1110,9 @@ class TankWriteNodeHandler(object):
         # write the template name to the node so that we know it later
         self.__update_knob_value(node, "render_template", render_template.name)
         self.__update_knob_value(node, "publish_template", publish_template.name)
-        self.__update_knob_value(node, "proxy_render_template", 
+        self.__update_knob_value(node, "proxy_render_template",
                                  proxy_render_template.name if proxy_render_template else "")
-        self.__update_knob_value(node, "proxy_publish_template", 
+        self.__update_knob_value(node, "proxy_publish_template",
                                  proxy_publish_template.name if proxy_publish_template else "")
 
         # If a node's tile_color was defined in the profile then set it:
@@ -1121,7 +1121,7 @@ class TankWriteNodeHandler(object):
                 # don't have exactly three values for RGB so log a warning:
                 self._app.log_warning(("The tile_color setting for profile '%s' must contain 3 values (RGB) - this "
                                     "setting will be ignored!") % profile_name)
-            
+
             # reset tile_color knob value back to default:
             default_value = int(node["tile_color"].defaultValue())
             self.__update_knob_value(node, "tile_color", default_value)
@@ -1130,8 +1130,8 @@ class TankWriteNodeHandler(object):
             # (Red << 24) + (Green << 16) + (Blue << 8)
             packed_rgb = 0
             for element in tile_color:
-                packed_rgb = (packed_rgb + min(max(element, 0), 255)) << 8 
-        
+                packed_rgb = (packed_rgb + min(max(element, 0), 255)) << 8
+
             self.__update_knob_value(node, "tile_color", packed_rgb)
 
         # Reset the render path but only if the named profile has changed - this will only
@@ -1148,8 +1148,8 @@ class TankWriteNodeHandler(object):
         if node.knob(TankWriteNodeHandler.OUTPUT_KNOB_NAME).value():
             # don't want to modify the current value if there is one
             return
-        
-        # first, check that output is actually used in the template and determine 
+
+        # first, check that output is actually used in the template and determine
         # the default value and if the key is optional.
         # (check for the 'channel' key as well for backwards compatibility)
         have_output_key = False
@@ -1162,15 +1162,15 @@ class TankWriteNodeHandler(object):
                 if output_default is None:
                     output_default = key.default
                 if output_is_optional:
-                    output_is_optional = template.is_optional(key_name)                
+                    output_is_optional = template.is_optional(key_name)
         if not have_output_key:
             # Nothing to do!
             return
-        
+
         if output_default is None:
             # no default name - use hard coded built in
             output_default = "output"
-        
+
         # get the output names for all other nodes that are using the same profile
         used_output_names = set()
         node_profile = self.get_node_profile_name(node)
@@ -1189,7 +1189,7 @@ class TankWriteNodeHandler(object):
         while output_name in used_output_names:
             output_name = "%s%d" % (output_default, postfix)
             postfix += 1
-        
+
         # finally, set the output name on the knob:
         node.knob(TankWriteNodeHandler.OUTPUT_KNOB_NAME).setValue(output_name)
 
@@ -1198,13 +1198,13 @@ class TankWriteNodeHandler(object):
     ):
         """
         Controls the file format of the write node
-        
+
         :param node:                    The Shotgun Write node to set the profile on
         :param file_type:               The file type to set on the internal Write node
         :param file_settings:           A dictionary of settings to set on the internal Write node
-        :param reset_all_settings:      Determines if all settings should be set on the internal Write 
+        :param reset_all_settings:      Determines if all settings should be set on the internal Write
                                         node (True) or just those that aren't propagated to the Shotgun
-                                        Write node (False) 
+                                        Write node (False)
         :param promoted_write_knobs:    A list of knob names that have been promoted from the
                                         encapsulated write node. In the case where reset_all_settings
                                         is false, these knobs are treated as user-controlled knobs
@@ -1213,10 +1213,10 @@ class TankWriteNodeHandler(object):
         # get the embedded write node
         write_node = node.node(TankWriteNodeHandler.WRITE_NODE_NAME)
         promoted_write_knobs = promoted_write_knobs or []
-        
+
         # set the file_type
         write_node.knob("file_type").setValue(file_type)
-        
+
         # and read it back to check that the value is what we expect
         if write_node.knob("file_type").value() != file_type:
             self._app.log_error("Shotgun write node configuration refers to an invalid file "
@@ -1227,8 +1227,8 @@ class TankWriteNodeHandler(object):
         # get a list of the settings we shouldn't update:
         knobs_to_skip = []
         if not reset_all_settings:
-            # Skip setting any knobs on the internal Write node that are represented by knobs on the 
-            # containing Shotgun Write node.  These knobs are typically only set at first creation 
+            # Skip setting any knobs on the internal Write node that are represented by knobs on the
+            # containing Shotgun Write node.  These knobs are typically only set at first creation
             # time or when the profile is changed as the artist is then free to change them.
             for knob_name in node.knobs():
                 knob = node.knob(knob_name)
@@ -1243,16 +1243,16 @@ class TankWriteNodeHandler(object):
             if setting_name in knobs_to_skip:
                 # skip this setting:
                 continue
-            
+
             knob = write_node.knob(setting_name)
             if knob is None:
-                self._app.log_error("%s is not a valid setting for file format %s. It will be ignored." 
+                self._app.log_error("%s is not a valid setting for file format %s. It will be ignored."
                                     % (setting_name, file_type))
                 continue
 
             knob.setValue(setting_value)
             if knob.value() != setting_value:
-                self._app.log_error("Could not set %s file format setting %s to '%s'. Instead the value was set to '%s'" 
+                self._app.log_error("Could not set %s file format setting %s to '%s'. Instead the value was set to '%s'"
                                     % (file_type, setting_name, setting_value, knob.value()))
 
         # If we're not resetting everything, then we need to try and
@@ -1309,10 +1309,10 @@ class TankWriteNodeHandler(object):
         Set the output on the specified node from user interaction.
         """
         self._app.log_debug("Changing the output for node '%s' to: %s" % (node.name(), output_name))
-        
+
         # update output knob:
         self.__update_knob_value(node, TankWriteNodeHandler.OUTPUT_KNOB_NAME, output_name)
-        
+
         # reset the render path:
         self.reset_render_path(node)
 
@@ -1343,7 +1343,7 @@ class TankWriteNodeHandler(object):
         """
         Update the render path and the various feedback knobs based on the current
         context and other node settings.
-        
+
         :param node:        The Shotgun Write node to update the path for
         :param force_reset: Force the path to be reset regardless of any cached
                             values
@@ -1362,8 +1362,8 @@ class TankWriteNodeHandler(object):
                 # width, height or format on a node can cause the evaluation
                 # of the internal Write node file/proxy to not be evaluated!!
                 return cached_path
-            
-            # it seems that querying certain things (e.g. node.width()) will sometimes cause the render 
+
+            # it seems that querying certain things (e.g. node.width()) will sometimes cause the render
             # and proxy paths to be re-evaluated causing this function to be called recursively which
             # can break things!  In case that happens we use some flags to track it so that the path
             # only gets updated once.
@@ -1377,10 +1377,10 @@ class TankWriteNodeHandler(object):
                     return cached_path
                 else:
                     self.__is_updating_render_path = True
-    
+
             # get the current script path:
             script_path = self.__get_current_script_path()
-                
+
             reset_path_button_visible = False
             path_warning = ""
             render_path = None
@@ -1388,7 +1388,7 @@ class TankWriteNodeHandler(object):
             try:
                 # gather the render settings to use when computing the path:
                 render_template, width, height, output_name = self.__gather_render_settings(node, is_proxy)
-                
+
                 # experimental settings cache to avoid re-computing the path if nothing has changed...
                 cache_item = self.__node_computed_path_settings_cache.get((node, is_proxy), (None, "", ""))
                 old_cache_entry, compute_path_error, render_path = cache_item
@@ -1399,7 +1399,7 @@ class TankWriteNodeHandler(object):
                     "output":output_name,
                     "script_path":script_path
                 }
-                
+
                 if (not force_reset) and old_cache_entry and cache_entry == old_cache_entry:
                     # nothing of relevance has changed since the last time the path was changed!
                     # if there was previously an error then raise it so that it gets reported properly:
@@ -1408,40 +1408,40 @@ class TankWriteNodeHandler(object):
                 else:
                     # compute the render path:
                     render_path = self.__compute_render_path_from(node, render_template, width, height, output_name)
-                    
+
             except TkComputePathError, e:
                 # update cache:
                 self.__node_computed_path_settings_cache[(node, is_proxy)] = (cache_entry, str(e), "")
-                
+
                 # render path could not be computed for some reason - display warning
                 # to the user in the property editor:
                 path_warning += "<br>".join(self.__wrap_text(
                         "The render path is currently frozen because Toolkit could not "
                         "determine a valid path!  This was due to the following problem:", 60)) + "<br>"
                 path_warning += "<br>"
-                path_warning += ("&nbsp;&nbsp;&nbsp;" 
-                                + " <br>&nbsp;&nbsp;&nbsp;".join(self.__wrap_text(str(e), 57)) 
+                path_warning += ("&nbsp;&nbsp;&nbsp;"
+                                + " <br>&nbsp;&nbsp;&nbsp;".join(self.__wrap_text(str(e), 57))
                                 + " <br>")
-                
+
                 if cached_path:
                     # have a previously cached path so we can at least still render:
                     path_warning += "<br>"
                     path_warning += "<br>".join(self.__wrap_text(
                         "You can still render to the frozen path but you won't be able to "
                         "publish this node!", 60))
-                
+
                 render_path = cached_path
             else:
                 # update cache:
                 self.__node_computed_path_settings_cache[(node, is_proxy)] = (cache_entry, "", render_path)
-                
+
                 path_is_locked = False
                 if not force_reset:
                     # if we force-reset the path then it will never be locked, otherwise we need to test
                     # to see if it is locked.  A path is considered locked if the render path differs
                     # from the cached path ignoring certain dynamic fields (e.g. width, height).
                     path_is_locked = self.__is_render_path_locked(node, render_path, cached_path, is_proxy)
-                
+
                 if path_is_locked:
                     # render path was not what we expected!
                     path_warning += "<br>".join(self.__wrap_text(
@@ -1451,25 +1451,25 @@ class TankWriteNodeHandler(object):
                     path_warning += "<br>".join(self.__wrap_text(
                         "The path will be automatically reset next time you version-up, publish "
                         "or click 'Reset Path'.", 60))
-                    
+
                     reset_path_button_visible = True
                     render_path = cached_path
-                
+
                 if not path_is_locked or not cached_path:
                     self.__update_knob_value(node, "tk_cached_proxy_path" if is_proxy else "cached_path", render_path)
-                    
+
                 # Also update the 'last known script' to be the current script
                 # this mechanism is used to determine if the script is being saved
                 # as a new file or as the same file in the onScriptSave callback
                 last_known_script_knob = node.knob("tk_last_known_script")
                 if force_reset or not last_known_script_knob.value():
                     last_known_script_knob.setValue(script_path)
-    
-            # Note that this method can get called to update the proxy render path when the node 
+
+            # Note that this method can get called to update the proxy render path when the node
             # isn't in proxy mode!  Because we only want to update the UI to represent the 'actual'
-            # state then we check for that here:  
+            # state then we check for that here:
             if is_proxy == node.proxy():
-                
+
                 # update warning displayed to the user:
                 if path_warning:
                     path_warning = "<i style='color:orange'><b><br>Warning</b><br>%s</i><br>" % path_warning
@@ -1479,11 +1479,11 @@ class TankWriteNodeHandler(object):
                     self.__update_knob_value(node, "path_warning", "")
                     node.knob("path_warning").setVisible(False)
                 node.knob("reset_path").setVisible(reset_path_button_visible)
-        
-                # show/hide proxy mode label depending if we're currently 
+
+                # show/hide proxy mode label depending if we're currently
                 # rendering in proxy mode:
                 node.knob("tk_render_mode").setVisible(is_proxy)
-                
+
                 # update the render warning label if needed:
                 render_warning = ""
                 if is_proxy:
@@ -1493,21 +1493,21 @@ class TankWriteNodeHandler(object):
                                           "Rendering in proxy mode will overwrite any previously rendered "
                                           "full-res frames!")
                 if render_warning:
-                    self.__update_knob_value(node, "tk_render_warning", 
-                                             "<i style='color:orange'><b>Warning</b> <br>%s<i><br>" 
+                    self.__update_knob_value(node, "tk_render_warning",
+                                             "<i style='color:orange'><b>Warning</b> <br>%s<i><br>"
                                              % "<br>".join(self.__wrap_text(render_warning, 60)))
                     node.knob("tk_render_warning").setVisible(True)
                 else:
                     self.__update_knob_value(node, "tk_render_warning", "")
                     node.knob("tk_render_warning").setVisible(False)
-                
+
                 # update output knobs:
                 self.__update_output_knobs(node)
-    
+
                 # finally, update preview:
                 self.__update_path_preview(node, is_proxy)
-    
-            return render_path           
+
+            return render_path
 
         finally:
             # make sure we reset the update flag
@@ -1515,7 +1515,7 @@ class TankWriteNodeHandler(object):
                 self.__is_updating_proxy_path = False
             else:
                 self.__is_updating_render_path = False
-        
+
     def __get_render_path(self, node, is_proxy=False):
         """
         Return the currently cached path for the specified node.  This will calculate the path
@@ -1528,15 +1528,15 @@ class TankWriteNodeHandler(object):
             path = node.knob("tk_cached_proxy_path").toScript()
         else:
             path = node.knob("cached_path").toScript()
-            
+
         if not path:
-            # never been cached so compute instead:                
+            # never been cached so compute instead:
             try:
                 path = self.__compute_render_path(node, is_proxy)
             except TkComputePathError:
                     # ignore
                     pass
-            
+
         return path
 
     def __get_files_on_disk(self, node, is_proxy=False):
@@ -1552,16 +1552,16 @@ class TankWriteNodeHandler(object):
                             "The path '%s' is not recognized by Shotgun!" % (node.name(), file_name))
 
         fields = template.get_fields(file_name)
-       
+
         # make sure we don't look for any eye - %V or SEQ - %04d stuff
         frames = self._app.tank.paths_from_template(template, fields, ["SEQ", "eye"])
-        
+
         return frames
 
     def __calculate_proxy_dimensions(self, node):
         """
         Calculate the proxy dimensions for the specified node.
-        
+
         Note, there must be an easier way to do this - have emailed support! - also
         this currently doesn't work if there is an upstream reformat node set to
         anything other than a format (e.g. scale, box)!
@@ -1569,53 +1569,53 @@ class TankWriteNodeHandler(object):
         if not nuke.exists("root"):
             return
         root = nuke.root()
-        
-        # calculate scale and offset to apply for proxy    
+
+        # calculate scale and offset to apply for proxy
         scale_x = scale_y = 1.0
         offset_x = offset_y = 0.0
-    
+
         proxy_type = root.knob("proxy_type").value()
         if proxy_type == "scale":
             # simple scale factor:
             scale_x = scale_y = root.knob("proxy_scale").value()
         elif proxy_type == "format":
             # Need to calculate scale and offset required to map the proxy format to the root format
-    
+
             # root format:
             root_format = root.format()
             root_w = root_format.width()
             root_h = root_format.height()
-            root_aspect = root_format.pixelAspect()    
-    
+            root_aspect = root_format.pixelAspect()
+
             # proxy format
             proxy_format = root.knob("proxy_format").value()
             proxy_w  = proxy_format.width()
             proxy_h  = proxy_format.height()
             proxy_aspect = proxy_format.pixelAspect()
-        
+
             # calculate scales and offsets required:
             scale_x = float(proxy_w)/float(root_w)
             scale_y = scale_x * (proxy_aspect/root_aspect)
-    
+
             offset_x = 0.0 # this always seems to be 0.0...
             offset_y = (((proxy_h/scale_y) - root_h) * scale_y)/2.0
         else:
             # unexpected type!
             pass
-    
+
         # calculate the scaled format for the node:
         scaled_format = node.format().scaled(scale_x,scale_y,offset_x,offset_y)
-                
-        #print ("sx:", scale_x, "sy:", scale_y, "tx:", offset_x, "ty:", offset_y, 
+
+        #print ("sx:", scale_x, "sy:", scale_y, "tx:", offset_x, "ty:", offset_y,
         #        "w:", scaled_format.width(), "h:", scaled_format.height())
         return (scaled_format.width(), scaled_format.height())
-        
+
 
     def __gather_render_settings(self, node, is_proxy=False):
         """
         Gather the render template, width, height and output name required
         to compute the render path for the specified node.
-        
+
         :param node:         The current Shotgun Write node
         :param is_proxy:     If True then compute the proxy path, otherwise compute the standard render path
         :returns:            Tuple containing (render template, width, height, output name)
@@ -1623,7 +1623,7 @@ class TankWriteNodeHandler(object):
         render_template = self.__get_render_template(node, is_proxy)
         width = height = 0
         output_name = ""
-        
+
         if is_proxy:
             if not render_template:
                 # we don't have a proxy template so fall back to render template.
@@ -1633,18 +1633,18 @@ class TankWriteNodeHandler(object):
                 # been specified then the full-res dimensions will be used instead
                 # of the proxy dimensions.
                 return self.__gather_render_settings(node, False)
-            
+
             # width & height are set to the proxy dimensions:
             width, height = self.__calculate_proxy_dimensions(node)
         else:
             # width & height are set to the node's dimensions:
             width, height = node.width(), node.height()
-        
+
         if render_template:
             # check for 'channel' for backwards compatibility
             if "output" in render_template.keys or "channel" in render_template.keys:
                 output_name = node.knob(TankWriteNodeHandler.OUTPUT_KNOB_NAME).value()
-            
+
         return (render_template, width, height, output_name)
 
 
@@ -1654,9 +1654,9 @@ class TankWriteNodeHandler(object):
 
         :param node:         The current Shotgun Write node
         :param is_proxy:     If True then compute the proxy path, otherwise compute the standard render path
-        :returns:            The computed render path        
+        :returns:            The computed render path
         """
-        
+
         # gather the render settings to use:
         render_template, width, height, output_name = self.__gather_render_settings(node, is_proxy)
 
@@ -1672,19 +1672,19 @@ class TankWriteNodeHandler(object):
         :param width:              The width of the rendered images
         :param height:             The height of the rendered images
         :param output_name:        The toolkit output name specified by the user for this node
-        :returns:                  The computed render path        
+        :returns:                  The computed render path
         """
 
         # make sure we have a valid template:
         if not render_template:
             raise TkComputePathError("Unable to determine the render template to use!")
-        
+
         # get the current script path:
         curr_filename = self.__get_current_script_path()
 
         # create fields dict with all the metadata
         #
-        
+
         # extract the work fields from the script path using the work_file template:
         fields = {}
         if curr_filename and self._script_template and self._script_template.validate(curr_filename):
@@ -1694,7 +1694,7 @@ class TankWriteNodeHandler(object):
 
         # Force use of %d format for nuke renders:
         fields["SEQ"] = "FORMAT: %d"
-        
+
         # use %V - full view printout as default for the eye field
         fields["eye"] = "%V"
 
@@ -1712,18 +1712,18 @@ class TankWriteNodeHandler(object):
         for key_name in ["output", "channel"]:
             if key_name in fields:
                 del(fields[key_name])
-            
+
             if key_name in render_template.keys:
                 if not output_name:
                     if not render_template.is_optional(key_name):
                         raise TkComputePathError("A valid output name is required by this profile for the '%s' field!"
                                                  % key_name)
                 else:
-                    if not render_template.keys[key_name].validate(output_name):                
+                    if not render_template.keys[key_name].validate(output_name):
                         raise TkComputePathError("The output name '%s' contains illegal characters!" % output_name)
-                    fields[key_name] = output_name            
-         
-        # update with additional fields from the context:       
+                    fields[key_name] = output_name
+
+        # update with additional fields from the context:
         fields.update(self._app.context.as_template_fields(render_template))
 
         # generate the render path:
@@ -1732,33 +1732,33 @@ class TankWriteNodeHandler(object):
             path = render_template.apply_fields(fields)
         except TankError, e:
             raise TkComputePathError(str(e))
-        
+
         # make slahes uniform:
         path = path.replace(os.path.sep, "/")
 
-        return path        
+        return path
 
     def __is_render_path_locked(self, node, render_path, cached_path, is_proxy=False):
         """
         Return True if the render path is currently locked because something unexpected
         has changed.  When the render path is locked, the cached version will always be
         used until it has been reset by an intentional user change/edit.
-        
+
         The path is locked if a new path generated with the previous template fields
-        would be different to the cached path ignoring the width & height fields. 
+        would be different to the cached path ignoring the width & height fields.
         """
         # get the render template:
         render_template = self.__get_render_template(node, is_proxy, fallback_to_render=True)
         if not render_template:
-            return True        
-        
+            return True
+
         path_is_locked = False
         if cached_path:
-            # Need to determine if something unexpected has changed in the file path that 
+            # Need to determine if something unexpected has changed in the file path that
             # we care about. To do this, we need to:
-            # - Extract previous fields from cached path - if this fails then it tells us 
+            # - Extract previous fields from cached path - if this fails then it tells us
             #   that a static part of the template has changed
-            # - Compare previous fields with new fields - this will tell us if a field we 
+            # - Compare previous fields with new fields - this will tell us if a field we
             #   care about has changed (we can ignore width, height differences).
             prev_fields = {}
             try:
@@ -1769,23 +1769,23 @@ class TankWriteNodeHandler(object):
             else:
                 # get the new fields from the render path and compare:
                 new_fields = render_template.get_fields(render_path)
-                
+
                 path_is_locked = (len(new_fields) != len(prev_fields))
                 if not path_is_locked:
                     for name, value in new_fields.iteritems():
                         if name not in prev_fields:
                             path_is_locked = True
                             break
-                        
+
                         if name in ["width", "height", "YYYY", "MM", "DD"]:
                             # ignore these as they are free to change!
                             continue
                         elif prev_fields[name] != value:
                             path_is_locked = True
                             break
-                        
-        return path_is_locked     
-                
+
+        return path_is_locked
+
     def __setup_new_node(self, node):
         """
         Setup a node when it's created (either directly or as a result of loading a script).
@@ -1800,14 +1800,14 @@ class TankWriteNodeHandler(object):
                   assume that setting up of these nodes only needs to happen once -
                   it needs to happen whenever the toolkit write node configuration
                   changes.
-        
+
         :param node:    The Shotgun Write Node to set up
         """
-        # check that this node is actually a Gizmo.  It might not be if 
+        # check that this node is actually a Gizmo.  It might not be if
         # it was created/loaded when the Gizmo wasn't available!
         if not isinstance(node, nuke.Gizmo):
             return
-        
+
         self._app.log_debug("Setting up new node...")
 
         # reset the construction flag to ensure that
@@ -1824,24 +1824,24 @@ class TankWriteNodeHandler(object):
             # to the list:
             current_profile_name = "%s [Not Found]" % current_profile_name
             profile_names.insert(0, current_profile_name)
-            
+
         list_profiles = node.knob("tk_profile_list").values()
         if list_profiles != profile_names:
             node.knob("tk_profile_list").setValues(profile_names)
-        
+
         reset_all_profile_settings = False
         if not current_profile_name:
             # default to first profile:
             current_profile_name = node.knob("tk_profile_list").value()
             # and as this node has never had a profile set, lets make
-            # sure we reset all settings 
-            reset_all_profile_settings = True 
-        
+            # sure we reset all settings
+            reset_all_profile_settings = True
+
         # ensure that the correct entry is selected from the list:
         self.__update_knob_value(node, "tk_profile_list", current_profile_name)
         # and make sure the node is up-to-date with the profile:
         self.__set_profile(node, current_profile_name, reset_all_settings=reset_all_profile_settings)
-        
+
         # ensure that the disable value properly propogates to the internal write node:
         write_node = node.node(TankWriteNodeHandler.WRITE_NODE_NAME)
         write_node["disable"].setValue(node["disable"].value())
@@ -1857,7 +1857,7 @@ class TankWriteNodeHandler(object):
             # force output name to be the node name:
             new_output_name = node.knob("name").value()
             self.__set_output(node, new_output_name)
-        
+
         # now that the node is constructed, we can process
         # knob changes correctly.
         self.__set_final_construction_flag(node, True)
@@ -1885,34 +1885,34 @@ class TankWriteNodeHandler(object):
         """
         if not node.knob("tk_is_fully_constructed"):
             return False
-        
+
         return node.knob("tk_is_fully_constructed").value()
-    
+
     def __on_knob_changed(self):
         """
         Callback that gets called whenever the value for a knob on a Shotgun Write
         node is set.
-        
+
         Note, this gets called numerous times when a script is loaded as well as when
         a knob is changed via the user/script
         """
         node = nuke.thisNode()
         knob = nuke.thisKnob()
         grp = nuke.thisGroup()
-        
+
         if not self.__is_node_fully_constructed(node):
-            # knobChanged will be called during script load for all knobs with non-default 
+            # knobChanged will be called during script load for all knobs with non-default
             # values.  We want to ignore these implicit changes so we make use of a knob to
             # keep track of the node creation.  If the node isn't fully created we ignore
             # all knob changes
             #print "Ignoring change to %s.%s value = %s" % (node.name(), knob.name(), knob.value())
             return
-        
+
         if knob.name() == "tk_profile_list":
             # change the profile for the specified node:
             new_profile_name = knob.value()
             self.__set_profile(node, new_profile_name, reset_all_settings=True)
-            
+
         elif knob.name() == TankWriteNodeHandler.OUTPUT_KNOB_NAME:
             # internal cached output has been changed!
             new_output_name = knob.value()
@@ -1920,13 +1920,13 @@ class TankWriteNodeHandler(object):
                 # force output name to be the node name:
                 new_output_name = node.knob("name").value()
             self.__set_output(node, new_output_name)
-            
+
         elif knob.name() == "name":
             # node name has changed:
             if node.knob(TankWriteNodeHandler.USE_NAME_AS_OUTPUT_KNOB_NAME).value():
                 # set the output to the node name:
                 self.__set_output(node, knob.value())
-                
+
         elif knob.name() == TankWriteNodeHandler.USE_NAME_AS_OUTPUT_KNOB_NAME:
             # checkbox controlling if the name should be used as the output has been toggled
             name_as_output = knob.value()
@@ -1934,7 +1934,7 @@ class TankWriteNodeHandler(object):
             if name_as_output:
                 # update output to reflect the node name:
                 self.__set_output(node, node.knob("name").value())
-                
+
         else:
             # Propogate changes to certain knobs from the gizmo/group to the
             # encapsulated Write node.
@@ -1942,7 +1942,7 @@ class TankWriteNodeHandler(object):
             # The normal mechanism of linking these knobs can't be used because the
             # knob already exists as part of the base node (it's not added by the gizmo)
             knobs_to_propogate = ["disable"]
-            
+
             # check if the value for this knob should be propogated:
             knob_name = knob.name()
             if knob_name in knobs_to_propogate:
@@ -1950,11 +1950,11 @@ class TankWriteNodeHandler(object):
                 write_node = grp.node(TankWriteNodeHandler.WRITE_NODE_NAME)
                 if not write_node:
                     return
-            
+
                 # propogate the value:
-                self._app.log_debug("Propogating value for '%s.%s' to '%s.%s.%s'" 
+                self._app.log_debug("Propogating value for '%s.%s' to '%s.%s.%s'"
                                     % (grp.name(), knob_name, grp.name(), write_node.name(), knob_name))
-                
+
                 write_node.knob(knob_name).setValue(nuke.thisKnob().value())
 
     def __get_current_script_path(self):
@@ -1964,7 +1964,7 @@ class TankWriteNodeHandler(object):
         back to the slightly less safe nuke.root().name() - this will result in an
         internal error (not a catchable exception) if the root object doesn't yet exist
         (e.g. whilst the file is being loaded).
-        
+
         :returns:   The current Nuke script path or None if the script hasn't been
                     saved yet.  The path will have os-correct slashes
         """
@@ -1983,18 +1983,18 @@ class TankWriteNodeHandler(object):
                 script_path = nuke.root().name()
                 if script_path == "Root":
                     script_path = None
-            
+
         if script_path:
             # convert to os-style slashes:
             script_path = script_path.replace("/", os.path.sep)
-            
+
         return script_path
-                
+
 
     def __on_script_save(self):
         """
         Called when the script is saved.
-        
+
         Iterates over the Shotgun write nodes in the scene.  If the script is being saved as
         a new file then it resets all render paths before saving
         """
@@ -2002,18 +2002,18 @@ class TankWriteNodeHandler(object):
         if not save_file_path:
             # script has never been saved as anything!
             return
-        
+
         for n in self.get_nodes():
             # check to see if the script is being saved to a new file or the same file:
             knob = n.knob("tk_last_known_script")
             if not knob:
                 continue
-             
+
             last_known_path = knob.value()
             if last_known_path:
                 # correct slashes for compare:
                 last_known_path = last_known_path.replace("/", os.path.sep)
-                
+
             if last_known_path != save_file_path:
                 # we're saving to a new file so reset the render path:
                 try:
@@ -2040,32 +2040,23 @@ class TankWriteNodeHandler(object):
                 "tk_write_node_settings",
                 unicode(base64.b64encode(knob_changes)),
             )
-                
+
     def __on_user_create(self):
         """
         Called when the user creates a Shotgun Write node.  Not called when loading
         or pasting a script.
         """
         node = nuke.thisNode()
-        
-        # check that this node is actually a Gizmo.  It might not be if 
+
+        # check that this node is actually a Gizmo.  It might not be if
         # it was created/loaded when the Gizmo wasn't available!
         if not isinstance(node, nuke.Gizmo):
             # it's not so we can't do anything!
             return
-        
+
         # setup the new node:
         self.__setup_new_node(node)
-        
+
         # populate the initial output name based on the render template:
         render_template = self.get_render_template(node)
         self.__populate_initial_output_name(render_template, node)
-
-
-
-
-
-
-
-        
-        


### PR DESCRIPTION
- created nuke autolabel that displays node name, file output, profile name, render order, and user label
- removed the hijack of the user label; now the user can set their own label
- renamed the menu entries to "sgWrite: profile" so they are easier to find with tab search
- added the "name" knob to the gizmo so that nuke names and auto-increments new nodes
- renamed the gizmos main tab to match the name of the gizmo: sgWrite
- added the "name" knob to the gizmo and called it "sgWrite1". Using this convention, nuke will auto-increment the number of the node
- removed the code that overrrides the node name and auto-increments in favor of the more nuke-centric approach above
- removed the "1" from the Input1 node so that nuke no longer displays a "1" on the gizmo input