### PR TITLE
SG-11834 fixes a bug with updating the writenode paths

### DIFF
--- a/app.py
+++ b/app.py
@@ -76,7 +76,10 @@ class NukeWriteNode(tank.platform.Application):
 
         # now the writenode handler settings have been updated we can update the paths of all existing SG writenodes
         for node in self.get_write_nodes():
-            self.reset_node_render_path(node)
+            # Although there are nuke callbacks to handle setting up the new node; on automatic context change
+            # these are triggered before the engine changes context, so we must manually call it here.
+            # this will force the path to reset and the profiles to be rebuilt.
+            self.__setup_new_node(node)
         
     def process_placeholder_nodes(self):
         """

--- a/app.py
+++ b/app.py
@@ -79,7 +79,7 @@ class NukeWriteNode(tank.platform.Application):
             # Although there are nuke callbacks to handle setting up the new node; on automatic context change
             # these are triggered before the engine changes context, so we must manually call it here.
             # this will force the path to reset and the profiles to be rebuilt.
-            self.__setup_new_node(node)
+            self.__write_node_handler.setup_new_node(node)
         
     def process_placeholder_nodes(self):
         """

--- a/app.py
+++ b/app.py
@@ -69,12 +69,14 @@ class NukeWriteNode(tank.platform.Application):
         :param old_context: The sgtk.context.Context being switched from.
         :param new_context: The sgtk.context.Context being switched to.
         """
-        for node in self.get_write_nodes():
-            self.reset_node_render_path(node)
 
         self.__write_node_handler.populate_profiles_from_settings()
         self.__write_node_handler.populate_script_template()
         self.__add_write_node_commands(new_context)
+
+        # now the writenode handler settings have been updated we can update the paths of all existing SG writenodes
+        for node in self.get_write_nodes():
+            self.reset_node_render_path(node)
         
     def process_placeholder_nodes(self):
         """

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -1405,7 +1405,6 @@ class TankWriteNodeHandler(object):
                     render_path = self.__compute_render_path_from(node, render_template, width, height, output_name)
                     
             except TkComputePathError as e:
-                self._app.log_exception(e)
                 # update cache:
                 self.__node_computed_path_settings_cache[(node, is_proxy)] = (cache_entry, str(e), "")
                 

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -204,7 +204,7 @@ class TankWriteNodeHandler(object):
         """
         Reset the render path of the specified node.  This
         will force the render path to be updated based on
-        the current script path and configuraton
+        the current script path and configuration.
         """
         is_proxy = node.proxy()
         self.__update_render_path(node, force_reset=True, is_proxy=is_proxy)     
@@ -1346,6 +1346,7 @@ class TankWriteNodeHandler(object):
                             just update the normal render path.
         :returns:           The updated render path
         """
+        self._app.logger.info("__update_render_path %r reset: %r" % (node, force_reset))
         try:
             # get the cached path without evaluating:
             cached_path = (node.knob("tk_cached_proxy_path").toScript() if is_proxy
@@ -1404,7 +1405,8 @@ class TankWriteNodeHandler(object):
                     # compute the render path:
                     render_path = self.__compute_render_path_from(node, render_template, width, height, output_name)
                     
-            except TkComputePathError, e:
+            except TkComputePathError as e:
+                self._app.log_exception(e)
                 # update cache:
                 self.__node_computed_path_settings_cache[(node, is_proxy)] = (cache_entry, str(e), "")
                 

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -356,7 +356,7 @@ class TankWriteNodeHandler(object):
 
         # set up all existing nodes:
         for n in self.get_nodes():
-            self.__setup_new_node(n)
+            self.setup_new_node(n)
         
     def remove_callbacks(self):
         """
@@ -596,7 +596,7 @@ class TankWriteNodeHandler(object):
         # alone from now on, unless we someday have a better understanding of
         # what's going on and the consequences of changing the on_node_created
         # behavior.
-        self.__setup_new_node(nuke.thisNode())
+        self.setup_new_node(nuke.thisNode())
 
     def on_compute_path_gizmo_callback(self):
         """
@@ -1781,8 +1781,8 @@ class TankWriteNodeHandler(object):
                             break
                         
         return path_is_locked     
-                
-    def __setup_new_node(self, node):
+
+    def setup_new_node(self, node):
         """
         Setup a node when it's created (either directly or as a result of loading a script).
         This allows us to dynamically populate the profile list.
@@ -2051,7 +2051,7 @@ class TankWriteNodeHandler(object):
             return
         
         # setup the new node:
-        self.__setup_new_node(node)
+        self.setup_new_node(node)
         
         # populate the initial output name based on the render template:
         render_template = self.get_render_template(node)

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -1346,7 +1346,6 @@ class TankWriteNodeHandler(object):
                             just update the normal render path.
         :returns:           The updated render path
         """
-        self._app.logger.info("__update_render_path %r reset: %r" % (node, force_reset))
         try:
             # get the cached path without evaluating:
             cached_path = (node.knob("tk_cached_proxy_path").toScript() if is_proxy


### PR DESCRIPTION
This fixes a bug with the way the writenode paths were updated.
If you had automatic context switching enabled and you opened a file through the Nuke menu triggering the automatic context switching, and the file comes from an environment that is different to the current one, such as asset_step going to shot_step, then it would display on the writenode that the path had been frozen due to the current script not matching the workfile template.

![image (2)](https://user-images.githubusercontent.com/3777228/55795754-679bdf80-5ac0-11e9-8446-f6fc38f3e319.png)

This was caused because it attempted to update the writenode paths before it had updated the template settings.

**Edit**

Another similar bug was discovered, and so I've updated it to call the `self.__setup_new_node` method instead of `self.reset_node_render_path`, which should now not only reevaluate the path, but also rebuild the list of profiles, which was also not getting updated.
![image (2)](https://user-images.githubusercontent.com/3777228/55873920-d2b0e900-5b88-11e9-980b-4e25c3183572.png)
