### PR TITLE
Ignore tk-metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# ---- ignore special files written during config setup
+tk-metadata
+
+# compiled python files
 *.py[cod]
 
 # C extensions

--- a/gizmos/WriteTank.gizmo
+++ b/gizmos/WriteTank.gizmo
@@ -6,8 +6,8 @@ version 6.3
 #
 # addUserKnob syntax
 # ------------------
-# <id> - this is the id of the knob type to add.  A full list can be found here:
-#     http://docs.thefoundry.co.uk/nuke/63/ndkdevguide/knobs-and-handles/knobtypes.html
+# <id> - this is the id of the knob type to add. A full list can be found here:
+#     https://learn.foundry.com/nuke/developers/63/ndkdevguide/knobs-and-handles/knobtypes.html
 #
 # <name> - name of the knob used when querying it in nuke, e.g. node.knob("<name>")
 #
@@ -22,8 +22,8 @@ version 6.3
 # Additional knob flags
 # ---------------------
 # These are set/removed by doing +/-FLAG_NAME, e.g. +STARTLINE to ensure the knob starts a
-# new line in the property editor.  A full list of flags can be found here:
-#     http://docs.thefoundry.co.uk/nuke/63/ndkdevguide/knobs-and-handles/knobflags.html
+# new line in the property editor. A full list of flags can be found here:
+#     https://learn.foundry.com/nuke/developers/63/ndkdevguide/knobs-and-handles/knobflags.html
 #
 ##########################################################################################
 ##########################################################################################


### PR DESCRIPTION
Just a quick one to ignore `tk-metadata` folder.

Maybe this needs to be added for all the other apps/engines too? I've only seen it in [tk-config-default2](https://github.com/shotgunsoftware/tk-config-default2/blob/70cd488ace221caaedd9410d09c92acd0d5b81c5/.gitignore) so far