### PR TITLE
Implement convert single node

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
@@ -17,6 +17,7 @@ import os
 import nuke
 import tank
 from tank import TankError
+
 
 class NukeWriteNode(tank.platform.Application):
 
@@ -51,10 +52,10 @@ class NukeWriteNode(tank.platform.Application):
         Called when the app is unloaded/destroyed
         """
         self.log_debug("Destroying tk-nuke-writenode app")
-        
+
         # remove any callbacks that were registered by the handler:
         self.__write_node_handler.remove_callbacks()
-        
+
         # clean up the nuke module:
         if hasattr(nuke, "_shotgun_write_node_handler"):
             del nuke._shotgun_write_node_handler
@@ -80,7 +81,7 @@ class NukeWriteNode(tank.platform.Application):
             # these are triggered before the engine changes context, so we must manually call it here.
             # this will force the path to reset and the profiles to be rebuilt.
             self.__write_node_handler.setup_new_node(node)
-        
+
     def process_placeholder_nodes(self):
         """
         Convert any placeholder nodes to TK Write Nodes
@@ -89,14 +90,14 @@ class NukeWriteNode(tank.platform.Application):
 
     # interface for other apps to query write node info:
     #
-    
+
     # access general information:
     def get_write_nodes(self):
         """
         Return list of all write nodes
         """
         return self.__write_node_handler.get_nodes()
-    
+
     def get_node_name(self, node):
         """
         Return the name for the specified node
@@ -109,11 +110,11 @@ class NukeWriteNode(tank.platform.Application):
         is using
         """
         return self.__write_node_handler.get_node_profile_name(node)
-    
+
     def get_node_tank_type(self, node):
         """
         Return the tank type for the specified node
-        
+
         Note: Legacy version with old 'Tank Type' name - use
         get_node_published_file_type instead!
         """
@@ -124,7 +125,7 @@ class NukeWriteNode(tank.platform.Application):
         Return the published file type for the specified node
         """
         return self.__write_node_handler.get_node_tank_type(node)
-    
+
     def is_node_render_path_locked(self, node):
         """
         Determine if the render path for the specified node
@@ -134,77 +135,77 @@ class NukeWriteNode(tank.platform.Application):
         can happen if the file is moved on disk or if the template
         is changed.
         """
-        return self.__write_node_handler.render_path_is_locked(node)    
-    
+        return self.__write_node_handler.render_path_is_locked(node)
+
     # access full-res render information:
     def get_node_render_path(self, node):
         """
         Return the render path for the specified node
         """
-        return self.__write_node_handler.compute_render_path(node)    
-    
+        return self.__write_node_handler.compute_render_path(node)
+
     def get_node_render_files(self, node):
         """
         Return the list of rendered files for the node
         """
         return self.__write_node_handler.get_files_on_disk(node)
-    
+
     def get_node_render_template(self, node):
         """
         Return the render template for the specified node
         """
         return self.__write_node_handler.get_render_template(node)
-    
+
     def get_node_publish_template(self, node):
         """
         Return the publish template for the specified node
         """
         return self.__write_node_handler.get_publish_template(node)
-    
+
     # access proxy-res render information:
     def get_node_proxy_render_path(self, node):
         """
         Return the render path for the specified node
         """
-        return self.__write_node_handler.compute_proxy_path(node)    
-    
+        return self.__write_node_handler.compute_proxy_path(node)
+
     def get_node_proxy_render_files(self, node):
         """
         Return the list of rendered files for the node
         """
         return self.__write_node_handler.get_proxy_files_on_disk(node)
-    
+
     def get_node_proxy_render_template(self, node):
         """
         Return the render template for the specified node
         """
         return self.__write_node_handler.get_proxy_render_template(node)
-    
+
     def get_node_proxy_publish_template(self, node):
         """
         Return the publish template for the specified node
         """
-        return self.__write_node_handler.get_proxy_publish_template(node)    
-    
+        return self.__write_node_handler.get_proxy_publish_template(node)
+
     # useful utility functions:
     def generate_node_thumbnail(self, node):
         """
         Generate a thumnail for the specified node
         """
         return self.__write_node_handler.generate_thumbnail(node)
-    
+
     def reset_node_render_path(self, node):
         """
         Reset the render path of the specified node.  This
         will force the render path to be updated based on
         the current script path and configuration.
-        
+
         Note, this should really never be needed now that the
         path is reset automatically when the user changes something.
         """
         self.__write_node_handler.reset_render_path(node)
 
-    def convert_to_write_nodes(self, show_warning=False):
+    def convert_to_write_nodes(self, nodes=list(), show_warning=False):
         """
         Convert all Shotgun write nodes found in the current Script to regular
         Nuke Write nodes.  Additional toolkit information will be stored on 
@@ -223,8 +224,8 @@ class NukeWriteNode(tank.platform.Application):
             # defer importing the QT module so the app doesn't require QT unless running this method with the warning.
             from sgtk.platform.qt import QtGui
             res = QtGui.QMessageBox.question(None,
-                                             "Convert All SG Write Nodes?",
-                                             "This will convert all Shotgun write nodes to standard write nodes."
+                                             "Convert SG Write Nodes?",
+                                             "This will convert Shotgun write nodes to standard write nodes."
                                              "\nOK to proceed?",
                                              QtGui.QMessageBox.Yes | QtGui.QMessageBox.No)
 
@@ -233,9 +234,9 @@ class NukeWriteNode(tank.platform.Application):
                 continue_with_convert = False
 
         if continue_with_convert:
-            self.__write_node_handler.convert_sg_to_nuke_write_nodes()
+            self.__write_node_handler.convert_sg_to_nuke_write_nodes(nodes)
 
-    def convert_from_write_nodes(self, show_warning=False):
+    def convert_from_write_nodes(self, nodes=list(), show_warning=False):
         """
         Convert all regular Nuke Write nodes that have previously been converted
         from Shotgun Write nodes, back into Shotgun Write nodes.
@@ -251,19 +252,18 @@ class NukeWriteNode(tank.platform.Application):
             # defer importing the QT module so the app doesn't require QT unless running this method with the warning.
             from sgtk.platform.qt import QtGui
             res = QtGui.QMessageBox.question(None,
-                                             "Convert All Write Nodes?",
-                                             "This will convert any Shotgun Write Nodes that have been converted "
+                                             "Convert Write Nodes?",
+                                             "This will convert Shotgun Write Nodes that have been converted "
                                              "into standard write nodes back to their original form."
                                              "\nOK to proceed?",
                                              QtGui.QMessageBox.Yes | QtGui.QMessageBox.No)
-
 
             if res != QtGui.QMessageBox.Yes:
                 # User chose to abort the operation, we should not convert the write nodes
                 continue_with_convert = False
 
         if continue_with_convert:
-            self.__write_node_handler.convert_nuke_to_sg_write_nodes()
+            self.__write_node_handler.convert_nuke_to_sg_write_nodes(nodes)
 
     def create_new_write_node(self, profile_name):
         """
@@ -284,10 +284,10 @@ class NukeWriteNode(tank.platform.Application):
 
         for profile_name in self.__write_node_handler.profile_names:
             # add to toolbar menu
-            cb_fn = lambda pn=profile_name: self.__write_node_handler.create_new_node(pn)
+            def cb_fn(pn=profile_name): return self.__write_node_handler.create_new_node(pn)
             self.engine.register_command(
                 "%s [Shotgun]" % profile_name,
-                cb_fn, 
+                cb_fn,
                 dict(
                     type="node",
                     icon=write_node_icon,
@@ -307,8 +307,8 @@ class NukeWriteNode(tank.platform.Application):
             if not promoted_knob_write_nodes:
                 # no presets use promoted knobs so we are OK to register the menus.
 
-                convert_to_write_nodes_action = lambda :self.convert_to_write_nodes(show_warning=True)
-                convert_from_write_nodes_action = lambda: self.convert_from_write_nodes(show_warning=True)
+                def convert_to_write_nodes_action(): return self.convert_to_write_nodes(show_warning=True)
+                def convert_from_write_nodes_action(): return self.convert_from_write_nodes(show_warning=True)
 
                 self.engine.register_command(
                     "Convert SG Write Nodes to Write Nodes...",

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -386,7 +386,7 @@ class TankWriteNodeHandler(object):
         
         if nodes:
             # filter list to only sg write nodes:
-            sg_write_nodes = [x for x in nodes if x.Class() == SG_WRITE_NODE_CLASS]
+            sg_write_nodes = [x for x in nodes if x.Class() == TankWriteNodeHandler.SG_WRITE_NODE_CLASS]
         else:
             # get all sg write nodes:
             sg_write_nodes = self.get_nodes()
@@ -529,7 +529,7 @@ class TankWriteNodeHandler(object):
             or not proxy_render_template_knob
             or not proxy_publish_template_knob):
             # can't convert to a Shotgun Write Node as we have missing parameters!
-            continue
+            return
 
         # set as selected:
         wn.setSelected(True)

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -366,7 +366,7 @@ class TankWriteNodeHandler(object):
         nuke.removeOnScriptSave(self.__on_script_save)
         nuke.removeOnUserCreate(self.__on_user_create, nodeClass=TankWriteNodeHandler.SG_WRITE_NODE_CLASS)
 
-    def convert_sg_to_nuke_write_nodes(self):
+    def convert_sg_to_nuke_write_nodes(self, nodes=list()):
         """
         Utility function to convert all Shotgun Write nodes to regular
         Nuke Write nodes.
@@ -384,96 +384,105 @@ class TankWriteNodeHandler(object):
         # clear current selection:
         nukescripts.clear_selection_recursive()
         
-        # get write nodes:
-        sg_write_nodes = self.get_nodes()
+        if nodes:
+            # filter list to only sg write nodes:
+            sg_write_nodes = [x for x in nodes if x.Class() == SG_WRITE_NODE_CLASS]
+        else:
+            # get all sg write nodes:
+            sg_write_nodes = self.get_nodes()
+
         for sg_wn in sg_write_nodes:
-        
-            # set as selected:
-            sg_wn.setSelected(True)
-            node_name = sg_wn.name()
-            node_pos = (sg_wn.xpos(), sg_wn.ypos())
-            
-            # create new regular Write node:
-            new_wn = nuke.createNode("Write")
-            new_wn.setSelected(False)
-        
-            # copy across file & proxy knobs (if we've defined a proxy template):
-            new_wn["file"].setValue(sg_wn["cached_path"].evaluate())
-            if sg_wn["proxy_render_template"].value():
-                new_wn["proxy"].setValue(sg_wn["tk_cached_proxy_path"].evaluate())
-            else:
-                new_wn["proxy"].setValue("")
+            self.convert_sg_to_nuke_write_node(sg_wn)
 
-            # make sure file_type is set properly:
-            int_wn = sg_wn.node(TankWriteNodeHandler.WRITE_NODE_NAME)
-            new_wn["file_type"].setValue(int_wn["file_type"].value())
-        
-            # copy across any knob values from the internal write node.
-            for knob_name, knob in int_wn.knobs().iteritems():
-                # skip knobs we don't want to copy:
-                if knob_name in ["file_type", "file", "proxy", "beforeRender", "afterRender", 
-                              "name", "xpos", "ypos"]:
-                    continue
-                
-                if knob_name in new_wn.knobs():
-                    try:
-                        new_wn[knob_name].setValue(knob.value())
-                    except TypeError:
-                        # ignore type errors:
-                        pass
+    def convert_sg_to_nuke_write_node(self, node):
+        sg_wn = node
 
-            # Set the nuke write node to have create directories ticked on by default
-            # As toolkit hasn't created the output folder at this point.
-            new_wn["create_directories"].setValue(True)
+        # set as selected:
+        sg_wn.setSelected(True)
+        node_name = sg_wn.name()
+        node_pos = (sg_wn.xpos(), sg_wn.ypos())
         
-            # copy across select knob values from the Shotgun Write node:
-            for knob_name in ["tile_color", "postage_stamp", "label"]:
-                new_wn[knob_name].setValue(sg_wn[knob_name].value())
-        
-            # Store Toolkit specific information on write node
-            # so that we can reverse this process later
+        # create new regular Write node:
+        new_wn = nuke.createNode("Write")
+        new_wn.setSelected(False)
+    
+        # copy across file & proxy knobs (if we've defined a proxy template):
+        new_wn["file"].setValue(sg_wn["cached_path"].evaluate())
+        if sg_wn["proxy_render_template"].value():
+            new_wn["proxy"].setValue(sg_wn["tk_cached_proxy_path"].evaluate())
+        else:
+            new_wn["proxy"].setValue("")
 
-            # profile
-            knob = nuke.String_Knob("tk_profile_name")
-            knob.setValue(sg_wn["profile_name"].value())
-            new_wn.addKnob(knob)
+        # make sure file_type is set properly:
+        int_wn = sg_wn.node(TankWriteNodeHandler.WRITE_NODE_NAME)
+        new_wn["file_type"].setValue(int_wn["file_type"].value())
+    
+        # copy across any knob values from the internal write node.
+        for knob_name, knob in int_wn.knobs().iteritems():
+            # skip knobs we don't want to copy:
+            if knob_name in ["file_type", "file", "proxy", "beforeRender", "afterRender", 
+                            "name", "xpos", "ypos"]:
+                continue
             
-            # output
-            knob = nuke.String_Knob("tk_output")
-            knob.setValue(sg_wn[TankWriteNodeHandler.OUTPUT_KNOB_NAME].value())
-            new_wn.addKnob(knob)
-            
-            # use node name for output
-            knob = nuke.Boolean_Knob(TankWriteNodeHandler.USE_NAME_AS_OUTPUT_KNOB_NAME)
-            knob.setValue(sg_wn[TankWriteNodeHandler.USE_NAME_AS_OUTPUT_KNOB_NAME].value())
-            new_wn.addKnob(knob)
+            if knob_name in new_wn.knobs():
+                try:
+                    new_wn[knob_name].setValue(knob.value())
+                except TypeError:
+                    # ignore type errors:
+                    pass
+
+        # Set the nuke write node to have create directories ticked on by default
+        # As toolkit hasn't created the output folder at this point.
+        new_wn["create_directories"].setValue(True)
+    
+        # copy across select knob values from the Shotgun Write node:
+        for knob_name in ["tile_color", "postage_stamp", "label"]:
+            new_wn[knob_name].setValue(sg_wn[knob_name].value())
+    
+        # Store Toolkit specific information on write node
+        # so that we can reverse this process later
+
+        # profile
+        knob = nuke.String_Knob("tk_profile_name")
+        knob.setValue(sg_wn["profile_name"].value())
+        new_wn.addKnob(knob)
         
-            # templates
-            knob = nuke.String_Knob("tk_render_template")
-            knob.setValue(sg_wn["render_template"].value())
-            new_wn.addKnob(knob)
-            
-            knob = nuke.String_Knob("tk_publish_template")
-            knob.setValue(sg_wn["publish_template"].value())
-            new_wn.addKnob(knob)
-            
-            knob = nuke.String_Knob("tk_proxy_render_template")
-            knob.setValue(sg_wn["proxy_render_template"].value())
-            new_wn.addKnob(knob)
-            
-            knob = nuke.String_Knob("tk_proxy_publish_template")
-            knob.setValue(sg_wn["proxy_publish_template"].value())
-            new_wn.addKnob(knob)
+        # output
+        knob = nuke.String_Knob("tk_output")
+        knob.setValue(sg_wn[TankWriteNodeHandler.OUTPUT_KNOB_NAME].value())
+        new_wn.addKnob(knob)
         
-            # delete original node:
-            nuke.delete(sg_wn)
+        # use node name for output
+        knob = nuke.Boolean_Knob(TankWriteNodeHandler.USE_NAME_AS_OUTPUT_KNOB_NAME)
+        knob.setValue(sg_wn[TankWriteNodeHandler.USE_NAME_AS_OUTPUT_KNOB_NAME].value())
+        new_wn.addKnob(knob)
+    
+        # templates
+        knob = nuke.String_Knob("tk_render_template")
+        knob.setValue(sg_wn["render_template"].value())
+        new_wn.addKnob(knob)
         
-            # rename new node:
-            new_wn.setName(node_name)
-            new_wn.setXpos(node_pos[0])
-            new_wn.setYpos(node_pos[1])
+        knob = nuke.String_Knob("tk_publish_template")
+        knob.setValue(sg_wn["publish_template"].value())
+        new_wn.addKnob(knob)
+        
+        knob = nuke.String_Knob("tk_proxy_render_template")
+        knob.setValue(sg_wn["proxy_render_template"].value())
+        new_wn.addKnob(knob)
+        
+        knob = nuke.String_Knob("tk_proxy_publish_template")
+        knob.setValue(sg_wn["proxy_publish_template"].value())
+        new_wn.addKnob(knob)
+    
+        # delete original node:
+        nuke.delete(sg_wn)
+    
+        # rename new node:
+        new_wn.setName(node_name)
+        new_wn.setXpos(node_pos[0])
+        new_wn.setYpos(node_pos[1])
             
-    def convert_nuke_to_sg_write_nodes(self):
+    def convert_nuke_to_sg_write_nodes(self, nodes=list()):
         """
         Utility function to convert all Nuke Write nodes to Shotgun
         Write nodes (only converts Write nodes that were previously
@@ -489,88 +498,97 @@ class TankWriteNodeHandler(object):
         """
         # clear current selection:
         nukescripts.clear_selection_recursive()
-        
-        # get write nodes:
-        write_nodes = nuke.allNodes(group=nuke.root(), filter="Write", recurseGroups = True)
+
+        if nodes:
+             # filter list to only write nodes:
+            write_nodes = [x for x in nodes if x.Class() == "Write"]
+        else:
+            # get write nodes:
+            write_nodes = nuke.allNodes(group=nuke.root(), filter="Write", recurseGroups = True)
+
         for wn in write_nodes:
+            self.convert_nuke_to_sg_write_node(wn)
+
+    def convert_nuke_to_sg_write_node(self, node):
+        wn = node
+
+        # look for additional toolkit knobs:
+        profile_knob = wn.knob("tk_profile_name")
+        output_knob = wn.knob("tk_output")
+        use_name_as_output_knob = wn.knob(TankWriteNodeHandler.USE_NAME_AS_OUTPUT_KNOB_NAME)
+        render_template_knob = wn.knob("tk_render_template")
+        publish_template_knob = wn.knob("tk_publish_template")
+        proxy_render_template_knob = wn.knob("tk_proxy_render_template")
+        proxy_publish_template_knob = wn.knob("tk_proxy_publish_template")
+    
+        if (not profile_knob
+            or not output_knob
+            or not use_name_as_output_knob
+            or not render_template_knob
+            or not publish_template_knob
+            or not proxy_render_template_knob
+            or not proxy_publish_template_knob):
+            # can't convert to a Shotgun Write Node as we have missing parameters!
+            continue
+
+        # set as selected:
+        wn.setSelected(True)
+        node_name = wn.name()
+        node_pos = (wn.xpos(), wn.ypos())
         
-            # look for additional toolkit knobs:
-            profile_knob = wn.knob("tk_profile_name")
-            output_knob = wn.knob("tk_output")
-            use_name_as_output_knob = wn.knob(TankWriteNodeHandler.USE_NAME_AS_OUTPUT_KNOB_NAME)
-            render_template_knob = wn.knob("tk_render_template")
-            publish_template_knob = wn.knob("tk_publish_template")
-            proxy_render_template_knob = wn.knob("tk_proxy_render_template")
-            proxy_publish_template_knob = wn.knob("tk_proxy_publish_template")
+        # create new Shotgun Write node:
+        new_sg_wn = nuke.createNode(TankWriteNodeHandler.SG_WRITE_NODE_CLASS)
+        new_sg_wn.setSelected(False)
+
+        # copy across file & proxy knobs as well as all cached templates:
+        new_sg_wn["cached_path"].setValue(wn["file"].value())
+        new_sg_wn["tk_cached_proxy_path"].setValue(wn["proxy"].value())
+        new_sg_wn["render_template"].setValue(render_template_knob.value())
+        new_sg_wn["publish_template"].setValue(publish_template_knob.value())
+        new_sg_wn["proxy_render_template"].setValue(proxy_render_template_knob.value())
+        new_sg_wn["proxy_publish_template"].setValue(proxy_publish_template_knob.value())
         
-            if (not profile_knob
-                or not output_knob
-                or not use_name_as_output_knob
-                or not render_template_knob
-                or not publish_template_knob
-                or not proxy_render_template_knob
-                or not proxy_publish_template_knob):
-                # can't convert to a Shotgun Write Node as we have missing parameters!
+        # set the profile & output - this will cause the paths to be reset:
+        # Note, we don't call the method __set_profile() as we don't want to
+        # run all the normal logic that runs as part of switching the profile.
+        # Instead we want this node to be rebuilt as close as possible to the
+        # original before it was converted to a regular Nuke write node.
+        profile_name = profile_knob.value()
+        new_sg_wn["profile_name"].setValue(profile_name)
+        new_sg_wn["tk_profile_list"].setValue(profile_name)
+        new_sg_wn[TankWriteNodeHandler.OUTPUT_KNOB_NAME].setValue(output_knob.value())
+        new_sg_wn[TankWriteNodeHandler.USE_NAME_AS_OUTPUT_KNOB_NAME].setValue(use_name_as_output_knob.value())
+
+        # make sure file_type is set properly:
+        int_wn = new_sg_wn.node(TankWriteNodeHandler.WRITE_NODE_NAME)
+        int_wn["file_type"].setValue(wn["file_type"].value())
+
+        # copy across and knob values from the internal write node.
+        for knob_name, knob in wn.knobs().iteritems():
+            # skip knobs we don't want to copy:
+            if knob_name in ["file_type", "file", "proxy", "beforeRender", "afterRender", 
+                            "name", "xpos", "ypos", "disable", "tile_color", "postage_stamp",
+                            "label"]:
                 continue
-
-            # set as selected:
-            wn.setSelected(True)
-            node_name = wn.name()
-            node_pos = (wn.xpos(), wn.ypos())
             
-            # create new Shotgun Write node:
-            new_sg_wn = nuke.createNode(TankWriteNodeHandler.SG_WRITE_NODE_CLASS)
-            new_sg_wn.setSelected(False)
-
-            # copy across file & proxy knobs as well as all cached templates:
-            new_sg_wn["cached_path"].setValue(wn["file"].value())
-            new_sg_wn["tk_cached_proxy_path"].setValue(wn["proxy"].value())
-            new_sg_wn["render_template"].setValue(render_template_knob.value())
-            new_sg_wn["publish_template"].setValue(publish_template_knob.value())
-            new_sg_wn["proxy_render_template"].setValue(proxy_render_template_knob.value())
-            new_sg_wn["proxy_publish_template"].setValue(proxy_publish_template_knob.value())
+            if knob_name in int_wn.knobs():
+                try:
+                    int_wn[knob_name].setValue(knob.value())
+                except TypeError:
+                    # ignore type errors:
+                    pass
+    
+        # explicitly copy some settings to the new Shotgun Write Node instead:
+        for knob_name in ["disable", "tile_color", "postage_stamp"]:
+            new_sg_wn[knob_name].setValue(wn[knob_name].value())
             
-            # set the profile & output - this will cause the paths to be reset:
-            # Note, we don't call the method __set_profile() as we don't want to
-            # run all the normal logic that runs as part of switching the profile.
-            # Instead we want this node to be rebuilt as close as possible to the
-            # original before it was converted to a regular Nuke write node.
-            profile_name = profile_knob.value()
-            new_sg_wn["profile_name"].setValue(profile_name)
-            new_sg_wn["tk_profile_list"].setValue(profile_name)
-            new_sg_wn[TankWriteNodeHandler.OUTPUT_KNOB_NAME].setValue(output_knob.value())
-            new_sg_wn[TankWriteNodeHandler.USE_NAME_AS_OUTPUT_KNOB_NAME].setValue(use_name_as_output_knob.value())
-
-            # make sure file_type is set properly:
-            int_wn = new_sg_wn.node(TankWriteNodeHandler.WRITE_NODE_NAME)
-            int_wn["file_type"].setValue(wn["file_type"].value())
-
-            # copy across and knob values from the internal write node.
-            for knob_name, knob in wn.knobs().iteritems():
-                # skip knobs we don't want to copy:
-                if knob_name in ["file_type", "file", "proxy", "beforeRender", "afterRender", 
-                              "name", "xpos", "ypos", "disable", "tile_color", "postage_stamp",
-                              "label"]:
-                    continue
-                
-                if knob_name in int_wn.knobs():
-                    try:
-                        int_wn[knob_name].setValue(knob.value())
-                    except TypeError:
-                        # ignore type errors:
-                        pass
-        
-            # explicitly copy some settings to the new Shotgun Write Node instead:
-            for knob_name in ["disable", "tile_color", "postage_stamp"]:
-                new_sg_wn[knob_name].setValue(wn[knob_name].value())
-                
-            # delete original node:
-            nuke.delete(wn)
-        
-            # rename new node:
-            new_sg_wn.setName(node_name)
-            new_sg_wn.setXpos(node_pos[0])
-            new_sg_wn.setYpos(node_pos[1])       
+        # delete original node:
+        nuke.delete(wn)
+    
+        # rename new node:
+        new_sg_wn.setName(node_name)
+        new_sg_wn.setXpos(node_pos[0])
+        new_sg_wn.setYpos(node_pos[1])       
 
 
     ################################################################################################


### PR DESCRIPTION
This PR Implements an option to pass a list of nodes to app methods ```convert_to_write_nodes()``` and ```convert_from_write_nodes()``` to allow for conversion of only specified nodes rather than all nodes. Methods have ```nodes``` keyword argument which requires a list. If this argument is not supplied, methods work as usual - converting all nodes in the script. This keeps backward compatibility.

For the handler, I've decoupled conversion logic from the methods for easier maintenance.