### PR TITLE
Bugfix: Copy before/after render Python knobs

### DIFF
--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -39,6 +39,11 @@ class TankWriteNodeHandler(object):
     OUTPUT_KNOB_NAME = "tank_channel"
     USE_NAME_AS_OUTPUT_KNOB_NAME = "tk_use_name_as_channel"
 
+    SG_PYTHON_KNOBS = (
+        ("tk_before_render", "beforeRender"),
+        ("tk_after_render", "afterRender"),
+    )
+
     ################################################################################################
     # Construction
 
@@ -408,6 +413,10 @@ class TankWriteNodeHandler(object):
             int_wn = sg_wn.node(TankWriteNodeHandler.WRITE_NODE_NAME)
             new_wn["file_type"].setValue(int_wn["file_type"].value())
         
+            # Copy over Python Knobs
+            for sg_knob_name, wn_knob_name in self.SG_PYTHON_KNOBS:
+                new_wn[wn_knob_name].setValue(sg_wn[sg_knob_name].value())
+
             # copy across any knob values from the internal write node.
             for knob_name, knob in int_wn.knobs().iteritems():
                 # skip knobs we don't want to copy:
@@ -544,6 +553,10 @@ class TankWriteNodeHandler(object):
             # make sure file_type is set properly:
             int_wn = new_sg_wn.node(TankWriteNodeHandler.WRITE_NODE_NAME)
             int_wn["file_type"].setValue(wn["file_type"].value())
+
+            # Copy over Python Knobs
+            for sg_knob_name, wn_knob_name in self.SG_PYTHON_KNOBS:
+                new_sg_wn[sg_knob_name].setValue(wn[wn_knob_name].value())
 
             # copy across and knob values from the internal write node.
             for knob_name, knob in wn.knobs().iteritems():


### PR DESCRIPTION
Simple PR that fixes tk_before/after_render knob values not transferred during conversion.

It seems the current "before render" and "after render" Python knobs on the Shotgun Write node is not copied over to the Nuke write node (and vice versa) but the other Python knobs were.

Discovered this ourselves when implementing [our own default `beforeRender` callbacks](https://github.com/wwfxuk/tk-nuke-writenode/commit/ebaf87f536070b2fe72f13cd3130cb594caf90cc) and after finding there's only one occurrance of `tk_before_render` in `handler.py`

