### PR TITLE
SG-3141 Made the SEQ key optional

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -50,18 +50,18 @@ configuration:
                     type: tank_type
                 render_template:
                     type: template
-                    fields: context, version, SEQ, [channel], [output], [name], [width], [height], [eye], [YYYY], [MM], [DD], *
+                    fields: context, version, [SEQ], [channel], [output], [name], [width], [height], [eye], [YYYY], [MM], [DD], *
                 publish_template:
                     type: template
-                    fields: context, version, SEQ, [channel], [output], [name], [width], [height], [eye], [TankType], *
+                    fields: context, version, [SEQ], [channel], [output], [name], [width], [height], [eye], [TankType], *
                 proxy_render_template:
                     type: template
-                    fields: context, version, SEQ, [channel], [output], [name], [width], [height], [eye], *
+                    fields: context, version, [SEQ], [channel], [output], [name], [width], [height], [eye], *
                     allows_empty: True
                     default_value: null
                 proxy_publish_template:
                     type: template
-                    fields: context, version, SEQ, [channel], [output], [name], [width], [height], [eye], [TankType], *
+                    fields: context, version, [SEQ], [channel], [output], [name], [width], [height], [eye], [TankType], *
                     allows_empty: True
                     default_value: null
                 tile_color:


### PR DESCRIPTION
Making the SEQ key optional allows us to set up their templates to write out `.mov` files which do not require a frame number. Right now if you try to do this a default frame number gets added to the name.