### PR TITLE
Remove duplicate [Flow Production Tracking] string from node registry

### DIFF
--- a/app.py
+++ b/app.py
@@ -295,7 +295,7 @@ class NukeWriteNode(tank.platform.Application):
                 pn
             )
             self.engine.register_command(
-                "%s [Flow Production Tracking]" % profile_name,
+                profile_name,
                 cb_fn,
                 dict(
                     type="node",


### PR DESCRIPTION
Nuke's Tab menu has a limit of 50 characters, any registered commands with longer labels cause a bug that will not allow the normal function of pressing enter/return in the tab selection to create the node.

https://support.foundry.com/hc/en-us/articles/360004964599-ID-390562-Tab-Menu-can-t-autocomplete-auto-fill-node-names-if-the-name-is-longer-than-50-characters

![image](https://github.com/user-attachments/assets/e120f4f6-e7fa-4989-81d9-483a66d72e9d)


This PR is one part of a fix and removes duplicate `[Flow Production Tracking]`  from the command label.

I would also recommend revisiting the menu names for all Toolkit apps as a lot of app menus are now ridiculously long.
We can just rename the menu's `Flow` or `Flow PTR` which should be enough.