### PR TITLE
SG-36245 Drop compatibility with Python 2

### DIFF
--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -21,7 +21,10 @@ import nukescripts
 
 import sgtk
 from sgtk import TankError
-from tank_vendor import six
+try:
+    from tank_vendor import sgutils
+except ImportError:
+    from tank_vendor import six as sgutils
 
 
 # Special exception raised when the work file cannot be resolved.
@@ -1370,7 +1373,7 @@ class TankWriteNodeHandler(object):
 
             if tcl_settings:
                 decoded_settings = base64.b64decode(tcl_settings)
-                knob_settings = pickle.loads(six.ensure_binary(decoded_settings))
+                knob_settings = pickle.loads(sgutils.ensure_binary(decoded_settings))
                 # We're going to filter out everything that isn't one of our
                 # promoted write node knobs. This will allow us to make sure
                 # that those knobs are set to the correct value, regardless
@@ -2125,7 +2128,7 @@ class TankWriteNodeHandler(object):
                 self.__set_output(node, node.knob("name").value())
 
         else:
-            # Propogate changes to certain knobs from the gizmo/group to the
+            # Propagate changes to certain knobs from the gizmo/group to the
             # encapsulated Write node.
             #
             # The normal mechanism of linking these knobs can't be used because the
@@ -2228,7 +2231,7 @@ class TankWriteNodeHandler(object):
             self.__update_knob_value(
                 n,
                 "tk_write_node_settings",
-                six.ensure_text(base64.b64encode(knob_changes)),
+                sgutils.ensure_text(base64.b64encode(knob_changes)),
             )
 
     def __on_user_create(self):

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -927,7 +927,7 @@ class TankWriteNodeHandler(object):
         """
         Update the value for the specified knob on the specified node
         but only if it is different to the current value to avoid
-        unneccesarily invalidating the cache
+        unnecessarily invalidating the cache
         """
         current_value = node.knob(name).value()
         if new_value != current_value:

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -21,6 +21,7 @@ import nukescripts
 
 import sgtk
 from sgtk import TankError
+
 try:
     from tank_vendor import sgutils
 except ImportError:
@@ -411,7 +412,6 @@ class TankWriteNodeHandler(object):
         # get write nodes:
         sg_write_nodes = self.get_nodes()
         for sg_wn in sg_write_nodes:
-
             # set as selected:
             sg_wn.setSelected(True)
             node_name = sg_wn.name()
@@ -529,7 +529,6 @@ class TankWriteNodeHandler(object):
             group=nuke.root(), filter="Write", recurseGroups=True
         )
         for wn in write_nodes:
-
             # look for additional toolkit knobs:
             profile_knob = wn.knob("tk_profile_name")
             output_knob = wn.knob("tk_output")
@@ -737,7 +736,6 @@ class TankWriteNodeHandler(object):
 
         # if we have a valid render path then show it:
         if render_dir:
-
             # run the app
             if sgtk.util.is_linux():
                 cmd = 'xdg-open "%s"' % render_dir
@@ -1631,7 +1629,6 @@ class TankWriteNodeHandler(object):
             # isn't in proxy mode!  Because we only want to update the UI to represent the 'actual'
             # state then we check for that here:
             if is_proxy == node.proxy():
-
                 # update warning displayed to the user:
                 if path_warning:
                     path_warning = (

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -22,11 +22,6 @@ import nukescripts
 import sgtk
 from sgtk import TankError
 
-try:
-    from tank_vendor import sgutils
-except ImportError:
-    from tank_vendor import six as sgutils
-
 
 # Special exception raised when the work file cannot be resolved.
 class TkComputePathError(TankError):
@@ -1371,7 +1366,7 @@ class TankWriteNodeHandler(object):
 
             if tcl_settings:
                 decoded_settings = base64.b64decode(tcl_settings)
-                knob_settings = pickle.loads(sgutils.ensure_binary(decoded_settings))
+                knob_settings = pickle.loads(decoded_settings)
                 # We're going to filter out everything that isn't one of our
                 # promoted write node knobs. This will allow us to make sure
                 # that those knobs are set to the correct value, regardless
@@ -2228,7 +2223,7 @@ class TankWriteNodeHandler(object):
             self.__update_knob_value(
                 n,
                 "tk_write_node_settings",
-                sgutils.ensure_text(base64.b64encode(knob_changes)),
+                base64.b64encode(knob_changes).decode(),
             )
 
     def __on_user_create(self):


### PR DESCRIPTION
Remove usage from `six` and replaced with `sgutils`.